### PR TITLE
Translate all project Markdown files to English

### DIFF
--- a/.claude/commands/character.md
+++ b/.claude/commands/character.md
@@ -91,7 +91,7 @@ Assistant: Checking Asuka Sato's consistency.
 User: /character dialogue Asuka Sato
 Assistant: I will converse as Asuka Sato. Settings loaded.
 
-Hello. I'm Sato from the市立図書館 (City Library).
+Hello. I'm Sato from the City Library.
 What kind of book are you looking for today?
 If you'd like, I can help you.
 

--- a/.claude/commands/character.md
+++ b/.claude/commands/character.md
@@ -1,184 +1,184 @@
 ---
-description: "キャラクター作成・管理・対話シミュレーションを行うコマンド"
+description: "Command to create, manage, and simulate dialogue with characters"
 ---
 
-# character - AIと共にキャラクターを創造する
+# character - Create characters with AI
 
-キャラクター作成の全プロセスをガイドします。動機から始まり、身上調査書を経て、生きたキャラクターを生み出します。
+Guides the entire character creation process. Starting from motivation, through a personal history, to create a living character.
 
-## 引数の処理
+## Argument Processing
 
-コマンド引数: $ARGUMENTS
+Command arguments: $ARGUMENTS
 
-引数が与えられた場合、以下のように解釈します：
-- 引数なし → 対話形式でオプションを選択
-- `new` → 新規キャラクター作成
-- `develop [名前]` → 指定キャラクターの深化
-- `check [名前]` → 指定キャラクターの一貫性チェック
-- `dialogue [名前]` → 指定キャラクターとの対話シミュレーション
-- `motivate` → 動機リストから選択してキャラクター作成
+If arguments are given, they are interpreted as follows:
+- No arguments → Select options interactively
+- `new` → Create a new character
+- `develop [name]` → Develop the specified character
+- `check [name]` → Check consistency of the specified character
+- `dialogue [name]` → Simulate dialogue with the specified character
+- `motivate` → Create a character by selecting from a motivation list
 
-## 基本フロー
+## Basic Flow
 
-### 1. 動機の決定（最重要）
+### 1. Determine Motivation (Most Important)
 ```
-まず、このキャラクターの「何をしたい人なのか」を決めましょう。
-以下から選ぶか、オリジナルの動機を教えてください：
+First, let's decide "what this character wants to do."
+Please choose from the list below or provide an original motivation:
 
-【守護・保護系】
-- 大切な人を守りたい
-- 故郷を守りたい
-- 弱い者を助けたい
+【Guardian/Protection Type】
+- I want to protect someone important
+- I want to protect my hometown
+- I want to help the weak
 
-【成長・達成系】
-- 強くなりたい
-- 認められたい
-- 夢を叶えたい
+【Growth/Achievement Type】
+- I want to become stronger
+- I want to be recognized
+- I want to fulfill my dream
 
-【探求・発見系】
-- 真実を知りたい
-- 世界を見たい
-- 謎を解きたい
+【Exploration/Discovery Type】
+- I want to know the truth
+- I want to see the world
+- I want to solve a mystery
 
-あなたの選択：
+Your choice:
 ```
 
-### 2. 身上調査書の作成（30分）
-動機が決まったら、キャラクターの輪郭を作ります：
-- 基本データ（名前、年齢、職業など）
-- 内面的要素（好きなもの、恐れ、夢など）
-- 生活習慣（住居、日課、口癖など）
+### 2. Create Personal History (30 minutes)
+Once the motivation is decided, create the character's outline:
+- Basic data (name, age, occupation, etc.)
+- Internal elements (likes, fears, dreams, etc.)
+- Lifestyle habits (residence, daily routine, catchphrases, etc.)
 
-### 3. 3層構造の設定
-- **第1層（不変）**：動機、価値観、恐れ、矛盾
-- **第2層（準安定）**：感情パターン、関係性、成長方向
-- **第3層（可変）**：話し方、行動パターン、仕草
+### 3. Set 3-Layer Structure
+- **Layer 1 (Invariant)**: Motivation, values, fears, contradictions
+- **Layer 2 (Semi-stable)**: Emotional patterns, relationships, growth direction
+- **Layer 3 (Variable)**: Speech style, behavior patterns, gestures
 
-### 4. キャラクターの「芯」の確認
-- 絶対にしないこと
-- 必ずすること
-- 読者への約束
+### 4. Confirm Character "Core"
+- Things they absolutely will not do
+- Things they will always do
+- Promises to the reader
 
-## 実行例
+## Execution Examples
 
-### 新規作成の場合（$ARGUMENTS = "new"）
+### For New Creation ($ARGUMENTS = "new")
 ```
 User: /character new
-Assistant: 新しいキャラクターを作成しましょう！
+Assistant: Let's create a new character!
 
-まず最も重要な「動機」から決めていきます。
-このキャラクターは「何をしたい人」ですか？
+First, let's decide on the most important "motivation."
+What does this character "want to do"?
 
-1. 用意された動機リストから選ぶ
-2. オリジナルの動機を設定する
+1. Choose from a prepared motivation list
+2. Set an original motivation
 
-どちらにしますか？
+Which do you choose?
 ```
 
-### 一貫性チェックの場合（$ARGUMENTS = "check 佐藤明日香"）
+### For Consistency Check ($ARGUMENTS = "check Asuka Sato")
 ```
-User: /character check 佐藤明日香
-Assistant: 佐藤明日香の一貫性をチェックします。
+User: /character check Asuka Sato
+Assistant: Checking Asuka Sato's consistency.
 
-✅ 動機「知識を共有することで人々の可能性を広げたい」
-✅ すべての行動が動機から説明可能
-⚠️ 第3章で本を乱暴に扱うシーンあり → 要修正
-✅ 話し方の統一性は保たれている
-```
-
-### 対話シミュレーションの場合（$ARGUMENTS = "dialogue 佐藤明日香"）
-```
-User: /character dialogue 佐藤明日香
-Assistant: 佐藤明日香として対話します。設定を読み込みました。
-
-こんにちは。市立図書館の佐藤です。
-今日はどのような本をお探しですか？
-もしよろしければ、お手伝いさせていただきます。
-
-[内面：新しい来館者。どんな本が好きなのか興味深い]
+✅ Motivation "I want to expand people's potential by sharing knowledge."
+✅ All actions can be explained by motivation
+⚠️ Scene in Chapter 3 where books are handled roughly → Needs correction
+✅ Consistency of speech style is maintained
 ```
 
-### 引数なしの場合（$ARGUMENTS = ""）
+### For Dialogue Simulation ($ARGUMENTS = "dialogue Asuka Sato")
+```
+User: /character dialogue Asuka Sato
+Assistant: I will converse as Asuka Sato. Settings loaded.
+
+Hello. I'm Sato from the市立図書館 (City Library).
+What kind of book are you looking for today?
+If you'd like, I can help you.
+
+[Internal thought: A new visitor. I'm curious what kind of books they like.]
+```
+
+### For No Arguments ($ARGUMENTS = "")
 ```
 User: /character
-Assistant: キャラクター管理コマンドです。何をしますか？
+Assistant: This is the character management command. What would you like to do?
 
-1. new - 新しいキャラクターを作成
-2. develop [名前] - 既存キャラクターを深化
-3. check [名前] - 一貫性をチェック
-4. dialogue [名前] - 対話シミュレーション
-5. motivate - 動機リストから作成
+1. new - Create a new character
+2. develop [name] - Develop an existing character
+3. check [name] - Check consistency
+4. dialogue [name] - Simulate dialogue
+5. motivate - Create from motivation list
 
-選択してください（1-5）：
+Please select (1-5):
 ```
 
-## ワークスペース管理
+## Workspace Management
 
-### 作成したキャラクターの保存
+### Saving Created Characters
 ```
-# 推奨保存先
-my-characters/[キャラクター名].character.md
+# Recommended save location
+my-characters/[character-name].character.md
 
-# 例
+# Examples
 my-characters/tanaka-misaki.character.md
 my-characters/2025-06-protagonist/hero.character.md
 ```
 
-### ファイル管理のベストプラクティス
-1. **命名規則を統一**
-   - `[名前].character.md` 形式を推奨
-   - 日本語名の場合はローマ字化
+### File Management Best Practices
+1. **Standardize Naming Conventions**
+   - Recommend `[name].character.md` format
+   - Romanize Japanese names
 
-2. **フォルダで整理**
-   - 作品ごと: `my-characters/last-letter/`
-   - 時期ごと: `my-characters/2025-06/`
-   - 役割ごと: `my-characters/protagonists/`
+2. **Organize with Folders**
+   - By work: `my-characters/last-letter/`
+   - By period: `my-characters/2025-06/`
+   - By role: `my-characters/protagonists/`
 
-3. **自動的にGitから除外**
-   - `my-characters/`内のファイルは自動的に`.gitignore`で除外
-   - 安心して個人的なキャラクターを作成可能
+3. **Automatically Exclude from Git**
+   - Files in `my-characters/` are automatically excluded by `.gitignore`
+   - Create personal characters with peace of mind
 
-### テンプレートからの開始
+### Starting from a Template
 ```bash
-# テンプレートをコピーして開始
+# Copy template to start
 cp character-template/CHARACTER.md my-characters/new-character.character.md
 
-# CLaudeで編集
+# Edit with Claude
 /character develop new-character
 ```
 
-## プロンプトチェーン
+## Prompt Chain
 
-1. **動機決定フェーズ**
-   - 動機の選択/作成
-   - 共感ポイントの確認
-   - 動機から生まれる行動の予測
+1. **Motivation Determination Phase**
+   - Select/create motivation
+   - Confirm empathy points
+   - Predict actions arising from motivation
 
-2. **詳細設定フェーズ**
-   - 身上調査書の記入
-   - 3層構造への落とし込み
-   - 矛盾の意図的設計
+2. **Detailed Setting Phase**
+   - Fill in personal history
+   - Incorporate into 3-layer structure
+   - Intentionally design contradictions
 
-3. **検証フェーズ**
-   - 一貫性チェック
-   - サンプルシーン作成
-   - 必要に応じて調整
+3. **Verification Phase**
+   - Consistency check
+   - Create sample scenes
+   - Adjust as necessary
 
-## 注意事項
+## Important Notes
 
-- 既存の人気キャラクターの真似は厳禁
-- 動機は明確で共感を呼ぶものを
-- 矛盾は人間味のために意図的に設計
-- 「芯」の部分は絶対にブレさせない
+- Strictly avoid imitating existing popular characters
+- Motivations should be clear and evoke empathy
+- Contradictions should be intentionally designed for human-likeness
+- Never let the "core" part become blurred
 
-## 関連コマンド
+## Related Commands
 
-- `/story` - 作成したキャラクターで物語を構築
-- `/scene` - キャラクターを活かしたシーン作成
-- `/quality` - キャラクターの品質評価
+- `/story` - Construct a story with the created character
+- `/scene` - Create scenes that utilize the character
+- `/quality` - Evaluate character quality
 
-## ヒント
+## Hints
 
-💡 キャラクターは設定の集まりではなく、生きた人間として扱いましょう。
-💡 迷ったら動機に立ち返りましょう。
-💡 完璧を求めすぎず、まずは作ってみることが大切です。
+💡 Treat characters not as a collection of settings, but as living humans.
+💡 If you get lost, return to the motivation.
+💡 It's important to try creating first, without aiming for perfection too much.

--- a/.claude/commands/dialogue.md
+++ b/.claude/commands/dialogue.md
@@ -1,303 +1,303 @@
 ---
-description: "キャラクターの個性が光る自然な会話シーンを作成するコマンド"
+description: "Command to create natural conversation scenes that highlight character personalities"
 ---
 
-# dialogue - 生きた会話を作成する
+# dialogue - Create living conversations
 
-キャラクターの個性が光る、自然で印象的な会話シーンを作成します。
+Creates natural and impressive conversation scenes that highlight character personalities.
 
-## 引数の処理
+## Argument Processing
 
-コマンド引数: $ARGUMENTS
+Command arguments: $ARGUMENTS
 
-引数形式: [タイプ] [キャラクター1] [キャラクター2] [オプション]
+Argument format: [type] [character1] [character2] [options]
 
-引数が与えられた場合、以下のように解釈します：
-- 第1引数（タイプ）:
-  - `first-meet` → 初対面の会話
-  - `conflict` → 対立・議論
-  - `confession` → 告白・本音
-  - `casual` → 日常会話
-  - `revelation` → 真実の開示
-- 第2引数以降: キャラクター名（スペース区切り）
-- 追加オプション: 雰囲気、目的など
+If arguments are given, they are interpreted as follows:
+- 1st argument (type):
+  - `first-meet` → First meeting conversation
+  - `conflict` → Conflict/argument
+  - `confession` → Confession/true feelings
+  - `casual` → Casual conversation
+  - `revelation` → Disclosure of truth
+- 2nd argument onwards: Character names (space-separated)
+- Additional options: Atmosphere, purpose, etc.
 
-例: `first-meet 佐藤明日香 山田太郎`
+Example: `first-meet Asuka Sato Taro Yamada`
 
-## 使い方
+## Usage
 
 ```
-/dialogue [タイプ] [キャラクター1] [キャラクター2] [オプション]
+/dialogue [type] [character1] [character2] [options]
 ```
 
-## 会話タイプ
+## Conversation Types
 
-- `first-meet` - 初対面の会話
-- `conflict` - 対立・議論
-- `confession` - 告白・本音
-- `casual` - 日常会話
-- `revelation` - 真実の開示
+- `first-meet` - First meeting conversation
+- `conflict` - Conflict/argument
+- `confession` - Confession/true feelings
+- `casual` - Casual conversation
+- `revelation` - Disclosure of truth
 
-## オプション
+## Options
 
-- `--mood <雰囲気>` - 会話の雰囲気
-- `--purpose <目的>` - この会話の役割
-- `--length <やり取り数>` - 会話の長さ
-- `--subtext` - 言外の意味を重視
+- `--mood <atmosphere>` - Atmosphere of the conversation
+- `--purpose <purpose>` - Role of this conversation
+- `--length <turns>` - Length of the conversation
+- `--subtext` - Emphasize subtext (implicit meaning)
 
-## 会話作成の原則
+## Principles of Conversation Creation
 
-### 1. キャラクターの差別化
+### 1. Differentiate Characters
 ```
-【佐藤明日香】（図書館司書）
-- 丁寧で控えめな話し方
-- 「もしよろしければ」が口癖
-- 本の話題では饒舌に
+【Asuka Sato】 (Librarian)
+- Polite and modest way of speaking
+- Catchphrase: "If you'd like"
+- Becomes talkative when discussing books
 
-【山田太郎】（刑事）
-- 簡潔で事実重視
-- 「...そういうことか」が口癖
-- 感情を表に出さない
-```
-
-### 2. サブテキスト（言外の意味）
-```
-表面の会話：「今日は良い天気ですね」
-真の意味：「あなたと話したい」
-
-表面の会話：「別に構いませんよ」
-真の意味：「本当は嫌だけど仕方ない」
+【Taro Yamada】 (Detective)
+- Concise and fact-oriented
+- Catchphrase: "...So that's it."
+- Does not show emotions openly
 ```
 
-### 3. 会話のリズム
+### 2. Subtext (Implicit Meaning)
 ```
-長い台詞
-　↓
-短い返答
-　↓
-沈黙（間）
-　↓
-核心的な一言
+Surface conversation: "Nice weather today, isn't it?"
+True meaning: "I want to talk to you."
+
+Surface conversation: "I don't really mind."
+True meaning: "I actually don't want to, but I have no choice."
 ```
 
-## 実行例
-
-### 初対面の会話
+### 3. Rhythm of Conversation
 ```
-User: /dialogue first-meet --characters 佐藤明日香 山田太郎
-Assistant: 【初対面の会話シーン】
-
-場所：市立図書館の参考図書コーナー
-状況：山田刑事が事件の資料を探している
-
----
-
-明日香は、参考図書コーナーで困った様子の男性に気づいた。
-
-「あの...もしよろしければ、何かお探しですか？」
-
-男性——スーツ姿で、鋭い目つき——は振り返った。
-
-「...法律関係の本を」
-
-「どのような内容でしょうか？　刑法？　民法？」
-
-一瞬の間。
-
-「...過去の判例集。20年前の」
-
-明日香の表情が和らいだ。
-
-「それでしたら、こちらに。もしよろしければ、
-特定の事件をお探しですか？」
-
-「...ああ」
-
-山田は明日香の真っ直ぐな視線に、少し居心地の悪さを感じた。
-図書館司書というのは、こんなに相手の心を見透かすものなのか。
-
-[会話の狙い：性格の違いを際立たせつつ、今後の関係性の種を蒔く]
+Long line
+  ↓
+Short reply
+  ↓
+Silence (pause)
+  ↓
+Core statement
 ```
 
-### 対立の会話
-```
-User: /dialogue conflict --characters 美咲 息子 --mood 緊張
-Assistant: 【対立の会話シーン】
+## Execution Examples
 
-場所：閉店後の書店
-状況：書店を継ぐことについての話し合い
+### First Meeting Conversation
+```
+User: /dialogue first-meet --characters Asuka Sato Taro Yamada
+Assistant: 【First Meeting Conversation Scene】
+
+Location: Reference section of the city library
+Situation: Detective Yamada is looking for case materials
 
 ---
 
-「この店を閉めるって、本気で言ってるの？」
+Asuka noticed a man who seemed troubled in the reference section.
 
-美咲は売上帳簿から目を上げず、静かに答えた。
+"Um... If you'd like, are you looking for something?"
 
-「継ぐ人がいないなら、仕方ないでしょう」
+The man—in a suit, with sharp eyes—turned around.
 
-「俺が継ぐって言ったら？」
+"...Books related to law."
 
-ペンを置く音が、静かな店内に響いた。
+"What kind of content? Criminal law? Civil law?"
 
-「あなたには、あなたの人生があるでしょう」
+A moment of silence.
 
-「母さんにだって、祖母さんから継いだ時は別の人生があったはずだ」
+"...Past case collections. From 20 years ago."
 
-美咲は初めて息子の顔を真っ直ぐ見た。
-二十年前の自分と同じ目をしている。
+Asuka's expression softened.
 
-「...本当に、後悔しない？」
+"In that case, this way. If you'd like,
+are you looking for a specific case?"
 
-「母さんは後悔してる？」
+"...Yeah."
 
-[間：お互いの本音を探る沈黙]
+Yamada felt a little uncomfortable under Asuka's direct gaze.
+Are librarians always this good at seeing through people?
 
-「...してないわ」
-
-「じゃあ、俺も」
-
-[会話の核心：世代を超えた理解と決意]
+[Goal of the conversation: Highlight personality differences while sowing seeds for a future relationship]
 ```
 
-### 告白の会話
+### Conflict Conversation
 ```
-User: /dialogue confession --subtext --mood 切ない
-Assistant: 【告白の会話シーン】
+User: /dialogue conflict --characters Misaki Son --mood Tense
+Assistant: 【Conflict Conversation Scene】
 
-状況：言えなかった想いが、遠回しに伝わる瞬間
+Location: Bookstore after closing
+Situation: Discussion about inheriting the bookstore
 
 ---
 
-「明日、東京に戻るんだ」
+"Are you serious about closing this store?"
 
-「...そう」
+Misaki answered quietly without looking up from the sales ledger.
 
-海風が二人の間を通り抜けていく。
+"If there's no one to inherit it, it can't be helped."
 
-「また来るよ。きっと」
+"What if I said I'd inherit it?"
 
-「きっと、ね」
+The sound of a pen being placed echoed in the quiet store.
 
-彼女の声に込められた疑念を、彼は聞き逃さなかった。
+"You have your own life, don't you?"
 
-「信じてない？」
+"You must have had a different life too, Mom, when you inherited it from Grandma."
 
-「信じてる。あなたが『きっと』と言う時は、
-本当は自信がない時だってことも含めて」
+Misaki looked directly at her son's face for the first time.
+He had the same eyes she had twenty years ago.
 
-図星だった。
+"...You really won't regret it?"
 
-「...君は、いつも俺のことをよく見てるね」
+"Do you regret it, Mom?"
 
-「そういう仕事だから。人を見るのが」
+[Pause: Silence to explore each other's true feelings]
 
-嘘だ、と二人とも分かっていた。
+"...I don't."
 
-[真実：仕事だからじゃない。好きだから、見ていた]
+"Then, me neither."
+
+[Core of the conversation: Understanding and determination transcending generations]
 ```
 
-## ワークスペースでの会話管理
+### Confession Conversation
+```
+User: /dialogue confession --subtext --mood Poignant
+Assistant: 【Confession Conversation Scene】
 
-### 会話シーンの保存
-```
-# シーンの一部として保存
-my-stories/[作品名]/scenes/scene-XX-dialogue.md
+Situation: A moment when unspoken feelings are conveyed indirectly
 
-# 会話練習用
-drafts/dialogue-practice-[キャラ名].md
+---
 
-# 重要な会話は個別管理
-my-stories/[作品名]/key-dialogues/confession.md
-```
+"I'm going back to Tokyo tomorrow."
 
-### 会話のバージョン管理
-異なるバージョンを試す場合：
-```
-scene-05-confession-v1.md  # 直接的なバージョン
-scene-05-confession-v2.md  # 遠回しなバージョン
-scene-05-confession-final.md  # 採用版
-```
+"...I see."
 
-## 会話テクニック集
+The sea breeze passed between them.
 
-### 1. 三点リーダーの活用
-```
-「...」（沈黙・ためらい）
-「まあ...」（言いよどみ）
-「そうね...」（考えながら）
-```
+"I'll come again. I promise."
 
-### 2. 言い直し・中断
-```
-「それは——いや、なんでもない」
-「君のことを、その、つまり...」
-```
+"Promise, huh."
 
-### 3. 相手の言葉を繰り返す
-```
-A:「もう会えないかもしれない」
-B:「会えないかもしれない、か」
-→ 言葉の重みを強調
+He didn't miss the doubt in her voice.
+
+"You don't believe me?"
+
+"I believe you. Including the fact that when you say 'promise,'
+you're actually not confident."
+
+She hit the mark.
+
+"...You always see right through me, don't you?"
+
+"It's my job. To observe people."
+
+They both knew it was a lie.
+
+[Truth: It's not because of work. It's because I like you that I watched.]
 ```
 
-### 4. 問いかけで終わる
+## Workspace Conversation Management
+
+### Saving Conversation Scenes
 ```
-「本当にそれでいいの？」
-→ 読者にも考えさせる
-```
+# Save as part of a scene
+my-stories/[work-title]/scenes/scene-XX-dialogue.md
 
-## 会話の品質チェック
+# For conversation practice
+drafts/dialogue-practice-[character-name].md
 
-- [ ] キャラクターの個性が出ているか
-- [ ] 不自然な情報説明になっていないか
-- [ ] 適度な間（沈黙）があるか
-- [ ] サブテキストが効いているか
-- [ ] 会話だけで状況が理解できるか
-
-## NG例と改善
-
-### NG：説明的すぎる
-```
-❌「私は図書館司書の佐藤明日香です。
-   本を通じて人々を助けたいと思っています」
-
-✅「本をお探しですか？　
-   もしよろしければ、お手伝いさせていただきます」
+# Manage important conversations individually
+my-stories/[work-title]/key-dialogues/confession.md
 ```
 
-### NG：キャラクターが同じ話し方
+### Conversation Version Control
+When trying different versions:
 ```
-❌ A:「それは素晴らしいね」
-   B:「本当に素晴らしいね」
-
-✅ A:「へえ、いいじゃない」
-   B:「...悪くない」
+scene-05-confession-v1.md  # Direct version
+scene-05-confession-v2.md  # Indirect version
+scene-05-confession-final.md  # Adopted version
 ```
 
-## 会話から生まれるもの
+## Conversation Techniques
 
-1. **関係性の変化**
-   - 距離が縮まる/広がる
-   - 理解が深まる/誤解が生じる
+### 1. Utilize Ellipses
+```
+"... " (Silence/hesitation)
+"Well..." (Stammering)
+"Let me see..." (While thinking)
+```
 
-2. **物語の推進**
-   - 新情報の開示
-   - 決断や行動のきっかけ
+### 2. Restating/Interruption
+```
+"That's—no, it's nothing."
+"About you, well, I mean..."
+```
 
-3. **感情の共有**
-   - 読者との共感
-   - キャラクターへの愛着
+### 3. Repeating the Other Person's Words
+```
+A: "I might not be able to see you again."
+B: "Might not be able to see me again, huh."
+→ Emphasizes the weight of the words
+```
 
-## 関連コマンド
+### 4. Ending with a Question
+```
+"Is that really okay?"
+→ Makes the reader think too
+```
 
-- `/character` - 会話に使うキャラクター作成
-- `/scene` - 会話を含むシーン作成
-- `/quality` - 会話の自然さ評価
-- `/subtext` - 言外の意味を分析
+## Conversation Quality Check
+
+- [ ] Does it show the character's personality?
+- [ ] Is it not an unnatural information dump?
+- [ ] Is there appropriate pausing (silence)?
+- [ ] Is the subtext effective?
+- [ ] Can the situation be understood from the conversation alone?
+
+## NG Examples and Improvements
+
+### NG: Too explanatory
+```
+❌ "I am Asuka Sato, a librarian.
+   I want to help people through books."
+
+✅ "Are you looking for a book?
+   If you'd like, I can help you."
+```
+
+### NG: Characters speak the same way
+```
+❌ A: "That's wonderful, isn't it?"
+   B: "It's truly wonderful, isn't it?"
+
+✅ A: "Oh, that's nice."
+   B: "...Not bad."
+```
+
+## What Arises from Conversation
+
+1. **Changes in Relationships**
+   - Distance narrows/widens
+   - Understanding deepens/misunderstandings arise
+
+2. **Story Progression**
+   - Disclosure of new information
+   - Triggers for decisions or actions
+
+3. **Sharing of Emotions**
+   - Empathy with the reader
+   - Attachment to characters
+
+## Related Commands
+
+- `/character` - Create characters to use in conversation
+- `/scene` - Create scenes that include conversation
+- `/quality` - Evaluate the naturalness of conversation
+- `/subtext` - Analyze implicit meaning
 
 ## Tips
 
-💬 現実の会話を観察しよう
-💬 完璧な会話より、人間らしい会話を
-💬 沈黙も立派な会話の一部
-💬 キャラクターの「声」を聞こう
+💬 Observe real-life conversations
+💬 Aim for human-like conversations rather than perfect ones
+💬 Silence is also a valid part of conversation
+💬 Listen to the "voices" of your characters

--- a/.claude/commands/quality.md
+++ b/.claude/commands/quality.md
@@ -1,278 +1,278 @@
 ---
-description: "作品の品質を5軸で客観的に評価・改善するコマンド"
+description: "Command to objectively evaluate and improve work quality on 5 axes"
 ---
 
-# quality - 作品の品質を5軸で評価する
+# quality - Evaluate work quality on 5 axes
 
-作成した物語やシーンを客観的に評価し、改善点を明確にします。
+Objectively evaluates created stories and scenes, clarifying areas for improvement.
 
-## 引数の処理
+## Argument Processing
 
-コマンド引数: $ARGUMENTS
+Command arguments: $ARGUMENTS
 
-引数形式: [対象] [オプション]
+Argument format: [target] [options]
 
-引数が与えられた場合、以下のように解釈します：
-- 第1引数（評価対象）:
-  - `scene [シーン名]` → 特定シーンの評価
-  - `story [タイトル]` → 物語全体の評価
-  - `character [名前]` → キャラクターの一貫性評価
-  - `dialogue [シーン]` → 会話の自然さ評価
-- 追加オプション:
-  - `--detail` → 詳細な評価レポート
-  - `--fix` → 問題点の修正案を提示
-  - `--compare` → 修正前後の比較
+If arguments are given, they are interpreted as follows:
+- 1st argument (evaluation target):
+  - `scene [scene_name]` → Evaluate a specific scene
+  - `story [title]` → Evaluate the entire story
+  - `character [name]` → Evaluate character consistency
+  - `dialogue [scene]` → Evaluate conversation naturalness
+- Additional options:
+  - `--detail` → Detailed evaluation report
+  - `--fix` → Suggest fixes for problems
+  - `--compare` → Compare before and after fixes
 
-例: `scene 手紙の発見 --detail`
+Example: `scene Discovery of the letter --detail`
 
-## 使い方
+## Usage
 
 ```
-/quality [対象] [オプション]
+/quality [target] [options]
 ```
 
-## 評価対象
+## Evaluation Targets
 
-- `scene <シーン名>` - 特定シーンの評価
-- `story <タイトル>` - 物語全体の評価
-- `character <名前>` - キャラクターの一貫性評価
-- `dialogue <シーン>` - 会話の自然さ評価
+- `scene <scene_name>` - Evaluate a specific scene
+- `story <title>` - Evaluate the entire story
+- `character <name>` - Evaluate character consistency
+- `dialogue <scene>` - Evaluate conversation naturalness
 
-## オプション
+## Options
 
-- `--detail` - 詳細な評価レポート
-- `--fix` - 問題点の修正案を提示
-- `--compare` - 修正前後の比較
+- `--detail` - Detailed evaluation report
+- `--fix` - Suggest fixes for problems
+- `--compare` - Compare before and after fixes
 
-## 5軸評価システム（各10点満点）
+## 5-Axis Evaluation System (Max 10 points each)
 
-### 1. キャラクター一貫性
+### 1. Character Consistency
 ```
-評価ポイント：
-✓ 核となる動機に沿った行動か
-✓ 話し方・口調の統一性
-✓ 設定された関係性の維持
-✓ 意図的な矛盾vs意図しないブレ
-```
-
-### 2. 物理的論理性
-```
-評価ポイント：
-✓ 時間経過の整合性
-✓ 空間配置の一貫性
-✓ 因果関係の明確さ
-✓ 不自然な偶然の有無
+Evaluation points:
+✓ Actions aligned with core motivation
+✓ Consistency of speech style and tone
+✓ Maintenance of established relationships
+✓ Intentional contradictions vs. unintentional blurring
 ```
 
-### 3. 心理的自然さ
+### 2. Physical Logic
 ```
-評価ポイント：
-✓ 感情変化の段階的描写
-✓ 動機づけの明確さ
-✓ 関係性の自然な発展
-✓ 内面描写の深さ
-```
-
-### 4. 読みやすさ
-```
-評価ポイント：
-✓ 文章のリズムとテンポ
-✓ 情報量の適切さ
-✓ 場面転換の滑らかさ
-✓ 構成の分かりやすさ
+Evaluation points:
+✓ Consistency of time progression
+✓ Consistency of spatial arrangement
+✓ Clarity of cause and effect
+✓ Absence of unnatural coincidences
 ```
 
-### 5. 感情的インパクト
+### 3. Psychological Naturalness
 ```
-評価ポイント：
-✓ 共感できる瞬間の有無
-✓ 予想外の展開
-✓ 印象的な場面・台詞
-✓ 読後の余韻
-```
-
-## 実行例
-
-### シーン評価
-```
-User: /quality scene "手紙の発見"
-Assistant: 【シーン評価：手紙の発見】
-
-総合評価：42/50点
-
-1. キャラクター一貫性：9/10 ⭐⭐⭐⭐⭐
-   ✓ 美咲の「知識共有」の価値観が行動に表れている
-   ✓ 丁寧な所作が一貫している
-   △ 感情の高ぶりでやや説明的になった箇所あり
-
-2. 物理的論理性：8/10 ⭐⭐⭐⭐
-   ✓ 手紙の保存状態の説明が自然
-   ✓ 時系列が明確
-   ✗ 書店内の配置がやや不明瞭
-
-3. 心理的自然さ：9/10 ⭐⭐⭐⭐⭐
-   ✓ 驚きから受容への変化が段階的
-   ✓ 20年の重みが伝わる描写
-   ✓ 老婦人との関係性が自然
-
-4. 読みやすさ：7/10 ⭐⭐⭐⭐
-   ✓ 場面転換がスムーズ
-   ✗ 手紙の内容がやや長い
-   △ 後半でテンポが落ちる
-
-5. 感情的インパクト：9/10 ⭐⭐⭐⭐⭐
-   ✓ 時を超えた繋がりに感動
-   ✓ 予想外の真実
-   ✓ 希望を感じる結末
-
-【改善提案】
-1. 手紙の内容を200字程度削減
-2. 書店の空間描写を1-2行追加
-3. 説明的な心理描写を行動で表現
+Evaluation points:
+✓ Phased depiction of emotional changes
+✓ Clarity of motivation
+✓ Natural development of relationships
+✓ Depth of internal portrayal
 ```
 
-### 問題修正
+### 4. Readability
 ```
-User: /quality scene "手紙の発見" --fix
-Assistant: 【問題点の修正案】
-
-問題1：説明的な心理描写
-❌ 原文：
-「美咲は驚きと懐かしさが入り混じった複雑な感情を覚えた」
-
-✅ 修正案：
-「美咲の手が止まった。『美咲へ』という見慣れた文字が、
-二十年の時を超えて語りかけてくる」
-
-問題2：書店の配置が不明瞭
-✅ 追加描写案：
-「カウンターの奥、文学全集が並ぶ棚の前で、
-老婦人は一冊の本を抱えていた」
-
-問題3：手紙が長すぎる
-✅ 要約案：
-手紙の要点のみ描写し、美咲の反応を増やす
-「母の文字が、大切なことだけを綴っていた。
-『本は人を繋ぐ——』
-読み進める美咲の頬を、一筋の涙が伝った」
+Evaluation points:
+✓ Rhythm and tempo of writing
+✓ Appropriateness of information volume
+✓ Smoothness of scene transitions
+✓ Clarity of structure
 ```
 
-### キャラクター評価
+### 5. Emotional Impact
 ```
-User: /quality character 佐藤明日香
-Assistant: 【キャラクター一貫性評価：佐藤明日香】
-
-総合評価：優秀（45/50点）
-
-✅ 強み
-1. 動機「知識共有で人々の可能性を広げたい」が全編で一貫
-2. 口癖「もしよろしければ」が自然に使用
-3. 眼鏡を押し上げる仕草が効果的
-
-⚠️ 要注意
-1. 第5章で本を雑に扱うシーンあり
-   → 動機と矛盾する可能性
-
-📊 詳細分析
-- 動機の一貫性：10/10
-- 価値観の表現：9/10
-- 行動パターン：8/10
-- 話し方：9/10
-- 成長の自然さ：9/10
-
-【提案】
-第5章の修正：感情的になっても本は丁寧に扱う
+Evaluation points:
+✓ Presence of relatable moments
+✓ Unexpected developments
+✓ Memorable scenes/lines
+✓ Lingering impression after reading
 ```
 
-## 評価結果の管理
+## Execution Examples
 
-### 品質チェック記録の保存
+### Scene Evaluation
 ```
-# 作品ごとに評価を記録
-my-stories/[作品名]/quality-checks/
-├── check-2025-06-15.md    # 日付付き評価
-├── check-draft.md         # 下書き段階の評価
-└── check-final.md         # 最終評価
+User: /quality scene "Discovery of the letter"
+Assistant: 【Scene Evaluation: Discovery of the letter】
 
-# 評価テンプレート
-cp quality-check/checklist.md my-stories/[作品名]/quality-checks/check-[日付].md
+Overall Evaluation: 42/50 points
+
+1. Character Consistency: 9/10 ⭐⭐⭐⭐⭐
+   ✓ Misaki's value of "knowledge sharing" is reflected in her actions
+   ✓ Polite demeanor is consistent
+   △ Became slightly explanatory due to heightened emotions
+
+2. Physical Logic: 8/10 ⭐⭐⭐⭐
+   ✓ Explanation of letter's preservation state is natural
+   ✓ Timeline is clear
+   ✗ Bookstore layout is somewhat unclear
+
+3. Psychological Naturalness: 9/10 ⭐⭐⭐⭐⭐
+   ✓ Change from surprise to acceptance is gradual
+   ✓ Portrayal conveys the weight of 20 years
+   ✓ Relationship with the old woman is natural
+
+4. Readability: 7/10 ⭐⭐⭐⭐
+   ✓ Scene transitions are smooth
+   ✗ Letter content is a bit long
+   △ Tempo drops in the latter half
+
+5. Emotional Impact: 9/10 ⭐⭐⭐⭐⭐
+   ✓ Moved by the connection across time
+   ✓ Unexpected truth
+   ✓ Ending evokes hope
+
+【Improvement Suggestions】
+1. Reduce letter content by about 200 characters
+2. Add 1-2 lines describing the bookstore's space
+3. Express explanatory psychological descriptions through actions
 ```
 
-### 改善の追跡
+### Problem Fixing
+```
+User: /quality scene "Discovery of the letter" --fix
+Assistant: 【Problem Fix Suggestions】
+
+Problem 1: Explanatory psychological description
+❌ Original:
+"Misaki felt a complex mix of surprise and nostalgia."
+
+✅ Revision:
+"Misaki's hand stopped. The familiar handwriting of 'To Misaki'
+spoke to her across twenty years."
+
+Problem 2: Bookstore layout is unclear
+✅ Additional description:
+"Behind the counter, in front of the shelf lined with literary collections,
+the old woman held a single book."
+
+Problem 3: Letter is too long
+✅ Summary suggestion:
+Describe only the main points of the letter and increase Misaki's reactions.
+"Her mother's handwriting spelled out only what was important.
+'Books connect people—'
+As Misaki read on, a single tear traced down her cheek."
+```
+
+### Character Evaluation
+```
+User: /quality character Asuka Sato
+Assistant: 【Character Consistency Evaluation: Asuka Sato】
+
+Overall Evaluation: Excellent (45/50 points)
+
+✅ Strengths
+1. Motivation "I want to expand people's potential by sharing knowledge" is consistent throughout
+2. Catchphrase "If you'd like" is used naturally
+3. Gesture of pushing up glasses is effective
+
+⚠️ Caution
+1. Scene in Chapter 5 where books are handled carelessly
+   → May contradict motivation
+
+📊 Detailed Analysis
+- Motivation Consistency: 10/10
+- Value Expression: 9/10
+- Behavior Patterns: 8/10
+- Speech Style: 9/10
+- Naturalness of Growth: 9/10
+
+【Suggestion】
+Revise Chapter 5: Handle books carefully even when emotional
+```
+
+## Evaluation Result Management
+
+### Saving Quality Check Records
+```
+# Record evaluations per work
+my-stories/[work-title]/quality-checks/
+├── check-2025-06-15.md    # Dated evaluation
+├── check-draft.md         # Draft stage evaluation
+└── check-final.md         # Final evaluation
+
+# Evaluation template
+cp quality-check/checklist.md my-stories/[work-title]/quality-checks/check-[date].md
+```
+
+### Tracking Improvements
 ```markdown
-## 評価履歴
+## Evaluation History
 
-### 2025-06-15 初稿
-- 総合: 35/50
-- 主な問題: キャラクターの一貫性
+### 2025-06-15 First Draft
+- Overall: 35/50
+- Main issue: Character consistency
 
-### 2025-06-20 第2稿
-- 総合: 42/50
-- 改善: キャラクター修正完了
-- 残課題: 感情描写の深化
+### 2025-06-20 Second Draft
+- Overall: 42/50
+- Improvement: Character revisions complete
+- Remaining issue: Deepen emotional portrayal
 
-### 2025-06-25 最終稿
-- 総合: 46/50
-- 完成度: 出版可能レベル
+### 2025-06-25 Final Draft
+- Overall: 46/50
+- Completeness: Publishable level
 ```
 
-### 作品間の比較
+### Comparing Works
 ```
-# 自分の成長を可視化
+# Visualize your own growth
 my-stories/quality-summary.md
 
-作品A: 35/50 → 42/50
-作品B: 38/50 → 45/50
-作品C: 41/50 → 47/50
+Work A: 35/50 → 42/50
+Work B: 38/50 → 45/50
+Work C: 41/50 → 47/50
 ```
 
-## 改善アクションプラン
+## Improvement Action Plan
 
-### 優先度：高
-1. キャラクターの動機に反する行動を修正
-2. 物理的矛盾の解消
-3. 不自然な感情変化の調整
+### High Priority
+1. Correct actions contradicting character motivation
+2. Resolve physical contradictions
+3. Adjust unnatural emotional changes
 
-### 優先度：中
-1. 冗長な描写の削減
-2. 説明的な文章を行動描写に変換
-3. 伏線の効果的な配置
+### Medium Priority
+1. Reduce redundant descriptions
+2. Convert explanatory sentences to action descriptions
+3. Effective placement of foreshadowing
 
-### 優先度：低
-1. 文体の統一
-2. 細かい言い回しの調整
-3. 誤字脱字の修正
+### Low Priority
+1. Standardize writing style
+2. Adjust minor phrasing
+3. Correct typos and omissions
 
-## よくある問題パターン
+## Common Problem Patterns
 
 ### Lost in the Middle
-- 症状：中盤で重要情報が抜ける
-- 対策：重要情報を冒頭/結末に移動
+- Symptom: Important information is missing in the middle part
+- Countermeasure: Move important information to the beginning/end
 
-### キャラクターブレ
-- 症状：性格が場面で変わる
-- 対策：動機に立ち返って修正
+### Character Inconsistency
+- Symptom: Personality changes depending on the scene
+- Countermeasure: Revisit motivation and revise
 
-### 説明過多
-- 症状：すべてを言葉で説明
-- 対策：行動と情景で表現
+### Excessive Explanation
+- Symptom: Everything is explained in words
+- Countermeasure: Express through actions and scenery
 
-## 品質向上のサイクル
+## Quality Improvement Cycle
 
 ```
-評価 → 問題特定 → 修正案作成 → 
-実装 → 再評価 → 微調整 → 完成
+Evaluate → Identify Problems → Create Revisions →
+Implement → Re-evaluate → Fine-tune → Complete
 ```
 
-## 関連コマンド
+## Related Commands
 
-- `/character` - キャラクターの一貫性強化
-- `/story` - 物語構造の改善
-- `/scene` - シーンの書き直し
-- `/revise` - 総合的な推敲
+- `/character` - Strengthen character consistency
+- `/story` - Improve story structure
+- `/scene` - Rewrite scenes
+- `/revise` - Comprehensive revision
 
 ## Remember
 
-📊 数値は目安。読者の心に響くかが最重要
-📊 完璧を求めすぎない。80点で十分良作
-📊 評価は成長のため。創作の楽しさを忘れずに
+📊 Numbers are guidelines. What matters most is resonating with readers' hearts.
+📊 Don't aim for perfection. 80 points is good enough for a quality work.
+📊 Evaluation is for growth. Don't forget the joy of creation.

--- a/.claude/commands/scene.md
+++ b/.claude/commands/scene.md
@@ -1,36 +1,36 @@
 ---
-description: "印象的なシーンを五感に訴える描写で作成するコマンド"
+description: "Command to create impressive scenes with descriptions that appeal to the five senses"
 ---
 
-# scene - 印象的なシーンを作成する
+# scene - Create impressive scenes
 
-物語の中の一場面を、五感に訴える豊かな描写で作成します。
+Creates a scene in a story with rich descriptions that appeal to the five senses.
 
-## 引数の処理
+## Argument Processing
 
-コマンド引数: $ARGUMENTS
+Command arguments: $ARGUMENTS
 
-引数形式: [タイプ] [オプション]
+Argument format: [type] [options]
 
-引数が与えられた場合、以下のように解釈します：
-- `dialogue` → 会話中心のシーン作成
-- `action` → アクション中心のシーン作成
-- `emotion` → 感情描写中心のシーン作成
-- `transition` → 場面転換シーン作成
-- `climax` → クライマックスシーン作成
+If arguments are given, they are interpreted as follows:
+- `dialogue` → Create a dialogue-centered scene
+- `action` → Create an action-centered scene
+- `emotion` → Create an emotion-centered scene
+- `transition` → Create a scene transition
+- `climax` → Create a climax scene
 
-追加オプション（スペース区切りで指定）：
-- キャラクター名
-- 雰囲気（緊張、穏やか、etc）
-- 文字数
-- シーンの目的
+Additional options (specified space-separated):
+- Character name
+- Atmosphere (tense, calm, etc.)
+- Character count
+- Scene purpose
 
-例: `dialogue 佐藤明日香 緊張`
+Example: `dialogue Asuka Sato tense`
 
-## 引数解析の実装
+## Argument Parsing Implementation
 
 ```javascript
-// $ARGUMENTSを解析
+// Parse $ARGUMENTS
 const args = '$ARGUMENTS'.trim().split(/\s+/);
 let sceneType = args[0] || 'general';
 let character = '';
@@ -38,57 +38,57 @@ let mood = '';
 let length = '';
 let purpose = '';
 
-// 引数を解析
+// Parse arguments
 for (let i = 1; i < args.length; i++) {
     const arg = args[i];
     
-    // 数字なら文字数として扱う
+    // If it's a number, treat as character count
     if (/^\d+$/.test(arg)) {
         length = arg;
     }
-    // 雰囲気を表す単語
-    else if (['緊張', '穏やか', '静寂', '混沌', '喜び', '悲しみ', '懐かしさ', '緊迫'].includes(arg)) {
+    // Words representing atmosphere
+    else if (['tense', 'calm', 'quiet', 'chaotic', 'joyful', 'sad', 'nostalgic', 'suspenseful'].includes(arg)) {
         mood = arg;
     }
-    // その他はキャラクター名として扱う
+    // Otherwise, treat as character name
     else if (!character) {
         character = arg;
     }
-    // 2つ目以降の文字列は目的として結合
+    // Concatenate second and subsequent strings as purpose
     else {
         purpose += (purpose ? ' ' : '') + arg;
     }
 }
 ```
 
-## 解析結果の使用
+## Using Parsed Results
 
 ```javascript
-// 解析結果を表示
+// Display parsed results
 if (args.length > 0 && args[0] !== '') {
-    console.log('【引数を解析しました】');
-    console.log(`- シーンタイプ: ${sceneType}${getSceneTypeDescription(sceneType)}`);
-    if (character) console.log(`- キャラクター: ${character}`);
-    if (mood) console.log(`- 雰囲気: ${mood}`);
-    if (length) console.log(`- 文字数: ${length}文字`);
-    if (purpose) console.log(`- 目的: ${purpose}`);
+    console.log('【Arguments Parsed】');
+    console.log(`- Scene Type: ${sceneType}${getSceneTypeDescription(sceneType)}`);
+    if (character) console.log(`- Character: ${character}`);
+    if (mood) console.log(`- Atmosphere: ${mood}`);
+    if (length) console.log(`- Character Count: ${length} characters`);
+    if (purpose) console.log(`- Purpose: ${purpose}`);
     console.log('');
 }
 
-// シーンタイプの説明を取得
+// Get scene type description
 function getSceneTypeDescription(type) {
     const descriptions = {
-        'dialogue': '（会話中心）',
-        'action': '（アクション中心）',
-        'emotion': '（感情描写中心）',
-        'transition': '（場面転換）',
-        'climax': '（クライマックス）',
-        'general': '（汎用シーン）'
+        'dialogue': ' (Dialogue-centered)',
+        'action': ' (Action-centered)',
+        'emotion': ' (Emotion-centered)',
+        'transition': ' (Scene transition)',
+        'climax': ' (Climax)',
+        'general': ' (General scene)'
     };
     return descriptions[type] || '';
 }
 
-// 引数に基づいてシーンを生成
+// Generate scene based on arguments
 if (sceneType && sceneType !== 'general') {
     generateScene(sceneType, character, mood, length, purpose);
 } else {
@@ -96,254 +96,254 @@ if (sceneType && sceneType !== 'general') {
 }
 ```
 
-## シーン作成の基本構造
+## Basic Scene Structure
 
-### 1. 状況設定（セットアップ）
+### 1. Situation Setting (Setup)
 ```
-【外的要素】
-- 場所：具体的に、読者が想像できるように
-- 時間：時刻、季節、天候
-- 登場人物：誰がいて、どんな位置関係か
+【External Elements】
+- Location: Specific enough for the reader to imagine
+- Time: Time of day, season, weather
+- Characters: Who is there, and what is their positioning
 
-【内的要素】
-- 視点人物の心理状態
-- このシーンに入る前の出来事
-- 期待と不安
-```
-
-### 2. シーンの展開
-```
-導入（フック）：読者を引き込む最初の一文
-　↓
-展開（ビルドアップ）：緊張や期待を高める
-　↓
-転換（ターニングポイント）：何かが変わる瞬間
-　↓
-締め（余韻）：次への橋渡し
+【Internal Elements】
+- Psychological state of the point-of-view character
+- Events before this scene
+- Expectations and anxieties
 ```
 
-### 3. 描写のバランス
+### 2. Scene Development
 ```
-視覚：40%（見えるもの）
-聴覚：20%（聞こえるもの）
-心理：30%（感じること）
-その他：10%（触覚、嗅覚、味覚）
+Introduction (Hook): The first sentence that draws the reader in
+  ↓
+Development (Buildup): Increases tension or anticipation
+  ↓
+Turning Point: The moment something changes
+  ↓
+Conclusion (Lingering Effect): Bridge to the next scene
 ```
 
-## 実行例
-
-### 会話シーン（引数解析版）
+### 3. Description Balance
 ```
-User: /scene dialogue 佐藤明日香 緊張
-Assistant: 【引数を解析しました】
-- シーンタイプ: dialogue（会話中心）
-- キャラクター: 佐藤明日香
-- 雰囲気: 緊張
+Visual: 40% (What can be seen)
+Auditory: 20% (What can be heard)
+Psychological: 30% (What is felt)
+Other: 10% (Tactile, olfactory, gustatory)
+```
 
-【会話シーンを作成します】
+## Execution Examples
 
-設定：
-- キャラクター：佐藤明日香（図書館司書）
-- 雰囲気：緊張
-- 場所：図書館のカウンター
+### Dialogue Scene (Parsed Arguments Version)
+```
+User: /scene dialogue Asuka Sato tense
+Assistant: 【Arguments Parsed】
+- Scene Type: dialogue (Dialogue-centered)
+- Character: Asuka Sato
+- Atmosphere: tense
+
+【Creating Dialogue Scene】
+
+Settings:
+- Character: Asuka Sato (Librarian)
+- Atmosphere: tense
+- Location: Library counter
 
 ---
 
-明日香は返却された本の山を前に、手を止めた。見覚えのない革表紙の手帳が、その中に混じっている。
+Asuka stopped her hands in front of a pile of returned books. A leather-bound notebook she didn't recognize was mixed in.
 
-「あの...」
+"Um..."
 
-カウンターの向こうで、青年が落ち着きなく指を組んでいた。
+Across the counter, a young man was restlessly fidgeting with his fingers.
 
-「これ、お客様のものですか？」
+"Is this yours?"
 
-明日香が手帳を掲げると、青年の顔が見る間に赤くなった。
+When Asuka held up the notebook, the young man's face turned red in an instant.
 
-「それは...その...」
+"That's... well..."
 
-[心理：何か大切なものらしい。でも、なぜ本に紛れて？]
+[Psychological: It seems important. But why was it mixed with the books?]
 
-続けますか？
+Continue?
 ```
 
-### 感情シーン（複数オプション付き）
+### Emotion Scene (With Multiple Options)
 ```
-User: /scene emotion 田中美咲 懐かしさ 800
-Assistant: 【引数を解析しました】
-- シーンタイプ: emotion（感情描写中心）
-- キャラクター: 田中美咲
-- 雰囲気: 懐かしさ
-- 文字数: 800文字
+User: /scene emotion Misaki Tanaka nostalgic 800
+Assistant: 【Arguments Parsed】
+- Scene Type: emotion (Emotion-centered)
+- Character: Misaki Tanaka
+- Atmosphere: nostalgic
+- Character Count: 800 characters
 
-【感情描写シーンを作成します】
+【Creating Emotion Scene】
 
-設定：
-- キャラクター：田中美咲（書店店主）
-- 感情：懐かしさ
-- きっかけ：母の愛読書を見つける
-- 目標文字数：約800文字
+Settings:
+- Character: Misaki Tanaka (Bookstore owner)
+- Emotion: Nostalgia
+- Trigger: Finding her mother's favorite book
+- Target character count: Approx. 800 characters
 
 ---
 
-埃をかぶった『銀河鉄道の夜』を手に取った瞬間、美咲の指が止まった。
+The moment Misaki picked up the dusty "Night on the Galactic Railroad," her fingers paused.
 
-ページの間から、かすかにラベンダーの香りが漂う。母の香水だ。二十年経った今でも、この香りは美咲を別の時代へと運んでいく。
+A faint scent of lavender wafted from between the pages. Her mother's perfume. Even now, twenty years later, this scent transported Misaki to another era.
 
-「また宮沢賢治？」と笑いながら、母はよくこの本を抱えていた。病室のベッドサイドにも、最後までこの本があった。
+"Miyazawa Kenji again?" her mother would often say with a laugh, holding this book. This book was also by her bedside in the hospital room until the very end.
 
-美咲は本を胸に抱いた。固い表紙越しに、母の温もりを探すように。
+Misaki hugged the book to her chest, as if searching for her mother's warmth through the hard cover.
 
-[内面：涙は出ない。でも、胸の奥が静かに熱い]
+[Internal: No tears. But a quiet warmth deep inside her chest.]
 
-（文字数を調整して800文字程度に展開）
+(Expand to about 800 characters, adjusting character count)
 ```
 
-### アクションシーン（雰囲気のみ指定）
+### Action Scene (Atmosphere Only)
 ```
-User: /scene action 緊迫
-Assistant: 【引数を解析しました】
-- シーンタイプ: action（アクション中心）
-- 雰囲気: 緊迫
-- キャラクター: （自動生成）
+User: /scene action suspenseful
+Assistant: 【Arguments Parsed】
+- Scene Type: action (Action-centered)
+- Atmosphere: suspenseful
+- Character: (Auto-generated)
 
-【アクションシーンを作成します】
+【Creating Action Scene】
 
-雰囲気：緊迫
-シーンの目的：危機的状況での決断
+Atmosphere: Suspenseful
+Scene Purpose: Decision in a critical situation
 
 ---
 
-階段を駆け上がる足音が、古い建物全体に響いた。
+The sound of footsteps rushing up the stairs echoed throughout the old building.
 
-三段飛ばしで上がりながら、翔は肩越しに振り返る。追手の影はまだ見えない。だが、時間の問題だ。
+Taking three steps at a time, Sho glanced over his shoulder. No sign of pursuers yet. But it was only a matter of time.
 
-最上階のドアが目前に迫る。鍵は掛かっているはずだ。体当たりするか、それとも—
+The door to the top floor loomed ahead. It should be locked. Ram it, or—
 
-「待て！」
+"Wait!"
 
-下から声が響いた。立ち止まれば終わりだ。
+A voice echoed from below. Stopping meant the end.
 
-翔は全体重を込めて、ドアに肩をぶつけた。
+Sho threw his entire weight against the door.
 
-[判断：今しかない]
+[Judgment: It's now or never.]
 ```
 
-### 引数なしの場合
+### No Arguments Case
 ```
 User: /scene
-Assistant: 【引数が指定されていません】
+Assistant: 【No Arguments Specified】
 
-シーンタイプを選択してください：
-1. dialogue - 会話中心のシーン
-2. action - アクション中心のシーン
-3. emotion - 感情描写中心のシーン
-4. transition - 場面転換シーン
-5. climax - クライマックスシーン
+Please select a scene type:
+1. dialogue - Dialogue-centered scene
+2. action - Action-centered scene
+3. emotion - Emotion-centered scene
+4. transition - Scene transition
+5. climax - Climax scene
 
-または、以下の形式で直接指定できます：
-/scene [タイプ] [キャラクター名] [雰囲気] [文字数]
+Alternatively, you can specify directly in the following format:
+/scene [type] [character_name] [atmosphere] [character_count]
 
-例：
-- /scene dialogue 山田太郎 緊張
-- /scene emotion 田中花子 喜び 500
-- /scene action 緊迫
+Examples:
+- /scene dialogue Taro Yamada tense
+- /scene emotion Hanako Tanaka joyful 500
+- /scene action suspenseful
 ```
 
-## ワークスペースでのシーン管理
+## Workspace Scene Management
 
-### シーンファイルの保存
+### Saving Scene Files
 ```
-# 個別シーンとして保存
-my-stories/[作品名]/scenes/scene-[番号]-[内容].md
+# Save as individual scenes
+my-stories/[work-title]/scenes/scene-[number]-[content].md
 
-# 例
+# Example
 my-stories/last-letter/scenes/scene-01-bookstore.md
 my-stories/last-letter/scenes/scene-02-letter-discovery.md
 my-stories/last-letter/scenes/scene-03-revelation.md
 ```
 
-### シーンの命名規則
-- `scene-[番号]-[内容].md` 形式を推奨
-- 番号は2桁（01, 02...）で統一
-- 内容は英語またはローマ字で簡潔に
+### Scene Naming Conventions
+- Recommend `scene-[number]-[content].md` format
+- Standardize numbers to two digits (01, 02...)
+- Content should be concise in English or Romaji
 
-### 下書きの管理
+### Draft Management
 ```
-# 実験的なシーンは drafts/ に
+# Experimental scenes in drafts/
 drafts/experimental-dialogue.draft.md
 drafts/alternative-ending.wip.md
 
-# 採用が決まったら正式な場所へ移動
+# Move to official location once adopted
 mv drafts/experimental-dialogue.draft.md my-stories/story-name/scenes/scene-04-dialogue.md
 ```
 
-### シーンの品質管理
-各シーンを作成したら：
-1. `/quality scene [シーン名]` で評価
-2. 問題点を修正
-3. 本編に組み込み
+### Scene Quality Control
+After creating each scene:
+1. Evaluate with `/quality scene [scene_name]`
+2. Correct any problems
+3. Incorporate into the main story
 
-## シーンタイプ別テクニック
+## Scene Type Specific Techniques
 
-### 会話シーン
-- 台詞の間に仕草を挟む
-- 沈黙も効果的に使う
-- サブテキスト（言外の意味）を意識
+### Dialogue Scene
+- Insert gestures between lines
+- Use silence effectively
+- Be aware of subtext (implicit meaning)
 
-### 感情シーン
-- 直接的な感情表現を避ける
-- 行動や情景で感情を表現
-- 五感を通じた記憶の描写
+### Emotion Scene
+- Avoid direct emotional expressions
+- Express emotions through actions and scenery
+- Describe memories through the five senses
 
-### アクションシーン
-- 短い文で緊迫感を演出
-- 動詞を効果的に使用
-- 時間の流れを明確に
+### Action Scene
+- Create tension with short sentences
+- Use verbs effectively
+- Clearly define the flow of time
 
-### 場面転換
-- 時間経過を自然に示す
-- 前シーンとの対比を活用
-- 新しい情報を少しずつ開示
+### Scene Transition
+- Naturally indicate the passage of time
+- Utilize contrast with the previous scene
+- Gradually disclose new information
 
-## 効果的な描写のコツ
+## Tips for Effective Description
 
 ### Show, Don't Tell
 ```
-❌ 彼は怒っていた。
-✅ 拳を握りしめ、顎の筋肉がぴくりと動いた。
+❌ He was angry.
+✅ He clenched his fists, and a muscle twitched in his jaw.
 ```
 
-### 比喩の活用
+### Utilize Metaphors
 ```
-❌ とても静かだった。
-✅ 図書館は、時が止まったように静まり返っていた。
-```
-
-### 感覚的描写
-```
-❌ 古い本がたくさんあった。
-✅ カビと埃の匂いが鼻をつき、革装丁の背表紙が薄暗い光を吸い込んでいた。
+❌ It was very quiet.
+✅ The library was as still as if time had stopped.
 ```
 
-## チェックリスト
+### Sensory Description
+```
+❌ There were many old books.
+✅ The smell of mold and dust stung the nostrils, and the leather-bound spines absorbed the dim light.
+```
 
-- [ ] シーンの目的は明確か
-- [ ] キャラクターらしさは出ているか
-- [ ] 五感に訴える描写があるか
-- [ ] 前後のシーンとの繋がりは自然か
-- [ ] 読者の感情を動かせるか
+## Checklist
 
-## 関連コマンド
+- [ ] Is the purpose of the scene clear?
+- [ ] Is the character's personality evident?
+- [ ] Are there descriptions that appeal to the five senses?
+- [ ] Is the connection with the preceding and succeeding scenes natural?
+- [ ] Can it move the reader's emotions?
 
-- `/character` - シーンで使うキャラクター作成
-- `/story` - シーンを組み込む物語構築
-- `/dialogue` - 会話に特化した作成
-- `/quality` - シーンの品質チェック
+## Related Commands
+
+- `/character` - Create characters to use in the scene
+- `/story` - Construct the story to incorporate the scene
+- `/dialogue` - Specialized creation for conversations
+- `/quality` - Check the quality of the scene
 
 ## Tips
 
-💡 最初の一文で読者を掴む
-💡 シーンの終わりは次への期待を残す
-💡 キャラクターの内面と外面のバランスを取る
-💡 長すぎるシーンは分割を検討
+💡 Grab the reader with the first sentence
+💡 End the scene leaving anticipation for what's next
+💡 Balance the character's internal and external aspects
+💡 Consider splitting scenes that are too long
 ```

--- a/.claude/commands/story.md
+++ b/.claude/commands/story.md
@@ -1,222 +1,222 @@
 ---
-description: "段階的に物語を構築するためのコマンド"
+description: "Command for constructing a story step-by-step"
 ---
 
-# story - 段階的に物語を構築する
+# story - Construct a story step-by-step
 
-キャラクターから物語を紡ぎ出す、3段階の構築プロセスをガイドします。
+Guides a 3-phase construction process to weave a story from characters.
 
-## 引数の処理
+## Argument Processing
 
-コマンド引数: $ARGUMENTS
+Command arguments: $ARGUMENTS
 
-引数が与えられた場合、以下のように解釈します：
-- 引数なし → 対話形式でオプションを選択
-- `new` → 新しい物語を構築開始
-- `plot [タイトル]` → 指定タイトルの物語のプロット展開
-- `scene [タイトル] [シーン番号]` → 特定シーンの詳細作成
-- `expand [タイトル]` → 短編を長編に展開
-- `analyze [タイトル]` → 物語構造の分析
+If arguments are given, they are interpreted as follows:
+- No arguments → Select options interactively
+- `new` → Start constructing a new story
+- `plot [title]` → Plot development for the specified story title
+- `scene [title] [scene_number]` → Detailed creation of a specific scene
+- `expand [title]` → Expand a short story into a long one
+- `analyze [title]` → Analysis of story structure
 
-## 段階的構築プロセス
+## Phased Construction Process
 
-### Phase 1: 骨組み（スケルトン）
+### Phase 1: Skeleton
 ```
-1. 主人公の設定確認
-2. 中心テーマの決定
-3. 始まりと終わりの設定
-4. 3幕構成の作成
-```
-
-### Phase 2: 重要シーンの特定
-```
-1. 転換点シーン（物語が動く瞬間）
-2. 感情のピークシーン（最も盛り上がる場面）
-3. テーマ体現シーン（主題が最も表れる場面）
+1. Confirm protagonist settings
+2. Determine central theme
+3. Set beginning and end
+4. Create 3-act structure
 ```
 
-### Phase 3: シーンの詳細設計
+### Phase 2: Identify Important Scenes
 ```
-1. 外的状況（場所、時間、登場人物）
-2. 内的状況（感情、欲求、恐れ）
-3. シーンの流れ（導入→展開→転換→締め）
-4. 必ず描くことチェックリスト
+1. Turning point scene (moment the story moves)
+2. Emotional peak scene (most exciting part)
+3. Theme embodiment scene (part where the theme is most expressed)
 ```
 
-## 実行例
+### Phase 3: Detailed Scene Design
+```
+1. External situation (location, time, characters)
+2. Internal situation (emotions, desires, fears)
+3. Scene flow (introduction → development → turning point → conclusion)
+4. Checklist of things to always depict
+```
 
-### 新規作成
+## Execution Examples
+
+### New Creation
 ```
 User: /story new
-Assistant: 新しい物語を構築しましょう！
+Assistant: Let's construct a new story!
 
-まず基本設定から始めます：
-- タイトル（仮でOK）：
-- ジャンル：
-- 想定文字数：
-- 主人公（作成済みキャラクターor新規）：
+First, let's start with basic settings:
+- Title (can be temporary):
+- Genre:
+- Estimated character count:
+- Protagonist (existing character or new):
 
-どれから決めていきましょうか？
+Which one shall we decide first?
 ```
 
-### プロット展開
+### Plot Development
 ```
-User: /story plot "最後の手紙"
-Assistant: 「最後の手紙」のプロット展開を行います。
+User: /story plot "The Last Letter"
+Assistant: Proceeding with plot development for "The Last Letter".
 
-現在の設定：
-- 主人公：田中美咲（45歳・書店店主）
-- テーマ：過去との和解と新たな一歩
+Current settings:
+- Protagonist: Misaki Tanaka (45 years old, bookstore owner)
+- Theme: Reconciliation with the past and a new step forward
 
-【3幕構成の詳細化】
+【Detailed 3-Act Structure】
 
-第1幕（設定）：
-1. 経営難の書店、美咲の日常描写（1,000字）
-2. 老婦人の来訪、本を探す（800字）
-3. 母の思い出の本との遭遇（700字）
+Act 1 (Setup):
+1. Struggling bookstore, depiction of Misaki's daily life (1,000 characters)
+2. Visit from an old woman, searching for a book (800 characters)
+3. Encounter with a book of her mother's memories (700 characters)
 
-続けて第2幕を展開しますか？
-```
-
-### シーン作成
-```
-User: /story scene "最後の手紙" 2
-Assistant: 「最後の手紙」第2シーン：老婦人との出会い
-
-【外的状況】
-場所：薄暗い書店の入り口付近
-時間：閉店間際の夕方6時、外は既に暗い
-天候：小雨が降り始めている
-
-【描写開始】
-カウンターで売上帳簿を閉じかけた美咲の耳に、扉の鈴の音が響いた。
-「申し訳ございません、もう閉店の時間で...」
-振り返った美咲の言葉が、途中で止まった。
-
-杖をついた老婦人が、雨に濡れた肩を小さく震わせながら立っていた。
-
-「少しだけ...本を探させていただけませんか」
-
-[続きを書きますか？]
+Shall we continue developing Act 2?
 ```
 
-## ワークスペース管理
+### Scene Creation
+```
+User: /story scene "The Last Letter" 2
+Assistant: "The Last Letter" Scene 2: Encounter with the old woman
 
-### 物語プロジェクトの構造
+【External Situation】
+Location: Near the entrance of a dimly lit bookstore
+Time: 6 PM, just before closing, already dark outside
+Weather: Light rain starting to fall
+
+【Begin Description】
+As Misaki was about to close the sales ledger at the counter, the sound of the door's bell echoed in her ears.
+"I'm sorry, we're already closed..."
+Misaki's words trailed off as she turned around.
+
+An old woman leaning on a cane stood there, her rain-soaked shoulders trembling slightly.
+
+"Could I just... look for a book for a little while?"
+
+[Continue writing?]
+```
+
+## Workspace Management
+
+### Story Project Structure
 ```
 my-stories/
-└── [作品名]/
-    ├── story.md          # メインストーリー
-    ├── outline.md        # プロット・構成
-    ├── characters/       # この作品のキャラクター
-    ├── scenes/          # 個別シーンファイル
+└── [work-title]/
+    ├── story.md          # Main story
+    ├── outline.md        # Plot/structure
+    ├── characters/       # Characters in this work
+    ├── scenes/          # Individual scene files
     │   ├── scene-01-opening.md
     │   ├── scene-02-meeting.md
     │   └── scene-03-climax.md
-    ├── chapters/        # 章ごとのファイル（長編の場合）
-    └── notes/          # メモ・アイデア
+    ├── chapters/        # Files per chapter (for long works)
+    └── notes/          # Memos/ideas
 ```
 
-### 新規プロジェクトの開始
+### Starting a New Project
 ```bash
-# 物語用のディレクトリを作成
+# Create a directory for the story
 mkdir -p my-stories/new-story/scenes
 
-# テンプレートをコピー
+# Copy the template
 cp story-template/STORY.md my-stories/new-story/story.md
 
-# キャラクターも関連付け
+# Also associate characters
 cp my-characters/protagonist.character.md my-stories/new-story/characters/
 ```
 
-### バージョン管理
-重要な作品は個別のGitリポジトリで管理：
+### Version Control
+Manage important works in individual Git repositories:
 ```bash
 cd my-stories/important-novel
 git init
 git add .
-git commit -m "第1稿完成"
+git commit -m "First draft complete"
 ```
 
-### 自動除外設定
-- `my-stories/`内のすべてのファイルは`.gitignore`で自動除外
-- テンプレートリポジトリに個人作品が混入する心配なし
+### Automatic Exclusion Settings
+- All files in `my-stories/` are automatically excluded by `.gitignore`
+- No need to worry about personal works getting mixed into the template repository
 
-## ストーリー構築のコツ
+## Story Construction Tips
 
-### Lost in the Middle対策
-- 重要情報は冒頭と結末に配置
-- 中盤は雰囲気と感情に集中
-- 定期的なリマインダーを挿入
+### Lost in the Middle Countermeasures
+- Place important information at the beginning and end
+- Focus on atmosphere and emotion in the middle
+- Insert periodic reminders
 
-### 感情曲線の設計
+### Designing the Emotional Curve
 ```
-高 |    ★ピーク
-   |   /  \
-   |  /    \★小さな山
-低 |★/      \★
-   |開始     結末
+High |    ★Peak
+     |   /  \
+     |  /    \★Small hill
+Low  |★/      \★
+     |Start     End
 ```
 
-### シーン転換テクニック
-1. 時間経過を明示
-2. 場所の変化を描写
-3. 視点人物の心理変化を追う
+### Scene Transition Techniques
+1. Clearly indicate time passage
+2. Describe changes in location
+3. Follow the psychological changes of the point-of-view character
 
-## 品質チェックポイント
+## Quality Checkpoints
 
-- [ ] 主人公の動機は一貫しているか
-- [ ] 物理的な矛盾はないか
-- [ ] 感情の流れは自然か
-- [ ] テーマは効果的に表現されているか
-- [ ] 各シーンに明確な役割があるか
+- [ ] Is the protagonist's motivation consistent?
+- [ ] Are there any physical contradictions?
+- [ ] Is the flow of emotions natural?
+- [ ] Is the theme effectively expressed?
+- [ ] Does each scene have a clear role?
 
-## ジャンル別アドバイス
+## Genre-Specific Advice
 
-### ミステリー
-- 手がかりはフェアに配置
-- 読者が推理可能な範囲で
-- 論理的な解決を重視
+### Mystery
+- Place clues fairly
+- Within a range the reader can deduce
+- Emphasize logical solutions
 
-### 恋愛小説
-- 感情の機微を丁寧に
-- 障害は現実的に設定
-- 関係性の変化を段階的に
+### Romance Novel
+- Carefully depict emotional subtleties
+- Set obstacles realistically
+- Show changes in relationships step-by-step
 
-### ファンタジー
-- 世界観のルールを明確に
-- でも説明過多は避ける
-- 人間ドラマを中心に
+### Fantasy
+- Clearly define world-building rules
+- But avoid excessive explanation
+- Focus on human drama
 
-## プロンプトチェーン
+## Prompt Chain
 
-1. **構想段階**
+1. **Conceptualization Phase**
    ```
-   キャラクター確認 → テーマ設定 → 
-   プロット作成 → 重要シーン選定
-   ```
-
-2. **執筆段階**
-   ```
-   シーン設計 → 下書き作成 → 
-   推敲 → 品質チェック
+   Character confirmation → Theme setting →
+   Plot creation → Important scene selection
    ```
 
-3. **仕上げ段階**
+2. **Writing Phase**
    ```
-   全体通読 → 不整合修正 → 
-   最終調整 → 完成
+   Scene design → Draft creation →
+   Revision → Quality check
    ```
 
-## 関連コマンド
+3. **Finishing Phase**
+   ```
+   Full read-through → Inconsistency correction →
+   Final adjustments → Completion
+   ```
 
-- `/character` - 物語の主人公を作成
-- `/scene` - 個別シーンの詳細作成
-- `/quality` - 物語の品質評価
-- `/dialogue` - 会話シーンの作成
+## Related Commands
+
+- `/character` - Create the protagonist of the story
+- `/scene` - Detailed creation of individual scenes
+- `/quality` - Evaluate the quality of the story
+- `/dialogue` - Create conversation scenes
 
 ## Remember
 
-📝 物語は段階的に育てるもの。最初から完璧を求めない。
-📝 キャラクターの動機がすべての原動力。
-📝 読者の感情を第一に考える。
+📝 Stories are nurtured step-by-step. Don't aim for perfection from the start.
+📝 Character motivation is the driving force behind everything.
+📝 Consider the reader's emotions first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ## Project Overview
 
-AI Story Forge (AIと共に物語を鍛える工房) is a comprehensive Japanese-language framework for AI-assisted creative writing. It provides structured templates, methodologies, and command tools for creating consistent characters and compelling narratives using generative AI.
+AI Story Forge (AI Story Creation Workshop) is a comprehensive English-language framework for AI-assisted creative writing. It provides structured templates, methodologies, and command tools for creating consistent characters and compelling narratives using generative AI.
 
 **Key Features**:
 - Motivation-driven character development system
@@ -51,9 +51,9 @@ ai-story-forge/
 Characters are built starting from their core motivation ("What does this person want?"), ensuring all actions and behaviors stem from this central drive.
 
 ### 2. Three-Layer Character System
-- **第1層：不変コア (Immutable Core)**: Core motivation, values, fears, and contradictions
-- **第2層：準安定層 (Semi-stable Layer)**: Emotional patterns, relationships, growth direction
-- **第3層：可変層 (Variable Layer)**: Speech patterns, behaviors, mannerisms
+- **Layer 1: Immutable Core**: Core motivation, values, fears, and contradictions
+- **Layer 2: Semi-stable Layer**: Emotional patterns, relationships, growth direction
+- **Layer 3: Variable Layer**: Speech patterns, behaviors, mannerisms
 
 ### 3. Three-Phase Story Construction
 - **Phase 1**: Skeleton (basic plot structure)
@@ -62,16 +62,16 @@ Characters are built starting from their core motivation ("What does this person
 
 ### 4. Five-Axis Quality Evaluation
 Each scene/story is evaluated on:
-1. Character consistency (キャラクター一貫性)
-2. Physical logic (物理的論理性)
-3. Psychological naturalness (心理的自然さ)
-4. Readability (読みやすさ)
-5. Emotional impact (感情的インパクト)
+1. Character consistency
+2. Physical logic
+3. Psychological naturalness
+4. Readability
+5. Emotional impact
 
 ## Working with This Repository
 
 ### For Template Development
-- Maintain Japanese language throughout
+- Maintain English language throughout
 - Follow established naming conventions
 - Keep examples in designated directories
 - Ensure consistency with core methodologies
@@ -106,7 +106,7 @@ The `.claude/commands/` directory contains five specialized commands (compatible
 
 Each command now supports:
 - **Argument handling**: Commands accept `$ARGUMENTS` for flexible usage
-- **Clear usage instructions** in Japanese
+- **Clear usage instructions** in English
 - **Multiple options and parameters**
 - **Practical examples with argument patterns**
 - **Integration with project templates**

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,155 +1,155 @@
-# 5分で始めるAI Story Forge
+# Get Started with AI Story Forge in 5 Minutes
 
-このガイドでは、AI Story Forgeを使って最初のキャラクターと物語の骨組みを5分で作成する方法を説明します。
+This guide explains how to create your first character and story outline in 5 minutes using AI Story Forge.
 
-## 🚀 ステップ1: プロジェクトの準備（1分）
+## 🚀 Step 1: Project Setup (1 minute)
 
-### リポジトリのクローン
+### Clone the repository
 ```bash
 git clone https://github.com/nwiizo/ai-story-forge.git
 cd ai-story-forge
 ```
 
-### または、必要なファイルだけコピー
-最小限必要なファイル：
+### Or, copy only the necessary files
+Minimum required files:
 - `character-template/CHARACTER.md`
 - `character-template/character-prompts.md`
 
-## 📝 ステップ2: キャラクター作成（3分）
+## 📝 Step 2: Character Creation (3 minutes)
 
-### 2-1. CHARACTER.mdをコピー
+### 2-1. Copy CHARACTER.md
 ```bash
 cp character-template/CHARACTER.md my-character.md
 ```
 
-### 2-2. 基本情報を記入
-まず、以下の4項目だけ埋めてください：
-- 名前
-- 年齢
-- 職業
-- 一言で表すと
+### 2-2. Fill in basic information
+First, please fill in only the following 4 items:
+- Name
+- Age
+- Occupation
+- In a nutshell
 
-### 2-3. AIとの対話でキャラクターを深める
+### 2-3. Deepen the character through dialogue with AI
 
-#### Claude Codeをお使いの場合
+#### If you are using Claude Code
 ```bash
-# 新規キャラクター作成
+# Create a new character
 /character new
 
-# または特定のキャラクターを深化
-/character develop 佐藤明日香
+# Or develop a specific character
+/character develop Asuka Sato
 ```
 
-#### その他のAIツールの場合
-`character-prompts.md`のStep 1をコピーして、お使いのAI（Claude、ChatGPT等）に投げてください：
+#### For other AI tools
+Copy Step 1 from `character-prompts.md` and paste it into your AI tool (Claude, ChatGPT, etc.):
 
 ```
-次の人物の最も大切にしている価値観を1つだけ設定してください。
+Please set only one most important value for the following person.
 
-[基本設定]
-- 年齢: 28歳
-- 職業: 図書館司書
-- 環境: 地方都市の公立図書館
+[Basic Settings]
+- Age: 28
+- Occupation: Librarian
+- Environment: Public library in a regional city
 
-条件：
-- 具体的で行動の指針となるもの
-- その人の人生の軸となるもの
-- 「○○を通じて△△したい」の形式で
+Conditions:
+- Specific and action-guiding
+- Something that forms the axis of their life
+- In the format "I want to △△ through ○○"
 ```
 
-AIの回答を`CHARACTER.md`の「核となる価値観」欄に記入します。
+Enter the AI's response in the "Core Value" section of `CHARACTER.md`.
 
-## 🎯 ステップ3: 簡単な物語の骨組み作成（1分）
+## 🎯 Step 3: Create a simple story outline (1 minute)
 
-### Claude Codeをお使いの場合
+### If you are using Claude Code
 ```bash
-# タイトルを指定して物語構築
-/story plot "最後の手紙"
+# Construct a story by specifying the title
+/story plot "The Last Letter"
 
-# または対話形式で開始
+# Or start in interactive mode
 /story
 ```
 
-### その他のAIツールの場合
-AIに以下を聞いてください：
+### For other AI tools
+Ask the AI the following:
 
 ```
-キャラクター：[作成したキャラクターの要約]
+Character: [Summary of the created character]
 
-このキャラクターが主人公の短い物語を作りたいです。
-1. どんな日常から始まりますか？（1行）
-2. どんな出来事が起きますか？（1行）
-3. 最後にキャラクターはどう変化しますか？（1行）
+I want to create a short story with this character as the protagonist.
+1. What kind of daily life does it start from? (1 line)
+2. What kind of event will occur? (1 line)
+3. How will the character change in the end? (1 line)
 ```
 
-これで物語の骨組みが完成です！
+Now your story outline is complete!
 
-## 🎮 Claude Codeのコマンド活用例
+## 🎮 Claude Code Command Usage Examples
 
-### キャラクター関連
+### Character-related
 ```bash
-/character new                    # 新規作成（対話形式）
-/character develop 田中美咲       # 既存キャラクターを深化
-/character check 佐藤明日香       # 一貫性をチェック
-/character dialogue 山田太郎      # 対話シミュレーション
+/character new                    # Create new (interactive)
+/character develop Misaki Tanaka  # Develop existing character
+/character check Asuka Sato       # Check consistency
+/character dialogue Taro Yamada   # Dialogue simulation
 ```
 
-### シーン作成
+### Scene creation
 ```bash
-/scene dialogue 佐藤明日香 緊張   # 会話中心のシーン
-/scene emotion 田中美咲 懐かしさ 800  # 感情描写（800文字）
-/scene action 緊迫               # アクションシーン
+/scene dialogue Asuka Sato tense   # Dialogue-focused scene
+/scene emotion Misaki Tanaka nostalgia 800  # Emotional description (800 characters)
+/scene action tense                # Action scene
 ```
 
-### 品質チェック
+### Quality check
 ```bash
-/quality scene "手紙の発見" --detail    # 詳細評価
-/quality character 佐藤明日香           # キャラクター評価
-/quality story "最後の手紙" --fix       # 改善提案付き
+/quality scene "Discovery of the letter" --detail    # Detailed evaluation
+/quality character Asuka Sato           # Character evaluation
+/quality story "The Last Letter" --fix       # With improvement suggestions
 ```
 
-## 💡 次のステップ
+## 💡 Next Steps
 
-### もう少し時間がある場合（+10分）
+### If you have a little more time (+10 minutes)
 
-1. **キャラクターを深める**
-   - `character-prompts.md`のStep 2-5を順番に実行
-   - 各ステップの回答をCHARACTER.mdに記入
+1. **Deepen the character**
+   - Execute Steps 2-5 of `character-prompts.md` in order
+   - Enter the answers for each step in CHARACTER.md
 
-2. **物語を具体化する**
-   - `story-template/STORY.md`を使用
-   - 3幕構成を作成
-   - 重要シーン3つを特定
+2. **Flesh out the story**
+   - Use `story-template/STORY.md`
+   - Create a 3-act structure
+   - Identify 3 important scenes
 
-3. **品質チェック**
-   - `quality-check/checklist.md`で確認
-   - 特に「キャラクター一貫性」を重視
+3. **Quality check**
+   - Check with `quality-check/checklist.md`
+   - Especially focus on "Character Consistency"
 
-## ❓ よくある質問
+## ❓ Frequently Asked Questions
 
-### Q: どのAIツールがおすすめ？
-A: **Claude Code**なら専用コマンドで効率的に作業できます。その他、長文処理なら**Claude Opus 4**、短い対話なら**ChatGPT**がおすすめです。
+### Q: Which AI tool is recommended?
+A: **Claude Code** allows you to work efficiently with dedicated commands. Otherwise, **Claude Opus 4** is recommended for long text processing, and **ChatGPT** for short dialogues.
 
-### Q: キャラクターがぶれてきたら？
-A: CHARACTER.mdの「核となる価値観」に立ち返ってください。すべての行動はこの価値観から生まれます。
+### Q: What if the character becomes inconsistent?
+A: Return to the "Core Value" in CHARACTER.md. All actions stem from this value.
 
-### Q: 物語が進まなくなったら？
-A: 重要シーン3つ（転換点・感情のピーク・テーマ体現）だけに集中し、他は後回しにしましょう。
+### Q: What if the story gets stuck?
+A: Concentrate on only three important scenes (turning point, emotional peak, theme embodiment) and leave others for later.
 
-## 🎉 成功のコツ
+## 🎉 Tips for Success
 
-1. **完璧を求めない** - 後でいくらでも修正できます
-2. **小さく始める** - まず1シーンだけ書いてみる
-3. **AIとの対話を楽しむ** - 予想外の回答も創造性の源
-4. **定期的に振り返る** - うまくいったプロンプトは記録
-5. **コマンドを活用** - Claude Codeなら`/`で効率化
+1. **Don't aim for perfection** - You can always revise later
+2. **Start small** - Try writing just one scene first
+3. **Enjoy dialogues with AI** - Unexpected answers are also a source of creativity
+4. **Reflect periodically** - Record prompts that worked well
+5. **Utilize commands** - With Claude Code, use `/` for efficiency
 
-## 📚 もっと学びたい方へ
+## 📚 For Those Who Want to Learn More
 
-- **詳細なテクニック**: `story-template/techniques.md`
-- **トラブルシューティング**: `quality-check/common-problems.md`
-- **理論的背景**: `resources/principles.md`
+- **Detailed techniques**: `story-template/techniques.md`
+- **Troubleshooting**: `quality-check/common-problems.md`
+- **Theoretical background**: `resources/principles.md`
 
 ---
 
-**始める準備はできましたか？** まずは`CHARACTER.md`を開いて、あなたの物語の主人公を生み出しましょう！
+**Are you ready to start?** First, open `CHARACTER.md` and bring your story's protagonist to life!

--- a/README.md
+++ b/README.md
@@ -1,161 +1,156 @@
-# AI Story Forge - AIと共に物語を鍛える工房
+# AI Story Forge - A workshop for forging stories with AI
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Version](https://img.shields.io/badge/version-0.0.2-blue.svg)](https://github.com/nwiizo/ai-story-forge/releases)
-[![Language](https://img.shields.io/badge/language-Japanese-green.svg)](https://github.com/nwiizo/ai-story-forge)
+[![Language](https://img.shields.io/badge/language-English-green.svg)](https://github.com/nwiizo/ai-story-forge)
 
-生成AIを活用した小説創作のための実践的なテンプレート集。キャラクターの一貫性を保ちながら、魅力的な物語を効率的に創作するためのシステムです。
+A collection of practical templates for novel writing using generative AI. This system helps you efficiently create compelling stories while maintaining character consistency.
 
-## 📌 最新情報 (v0.0.3)
+## 📌 Latest Information (v0.0.3)
 
-- 🆕 **Claude Code v1.0.25対応**: スラッシュコマンドに引数を渡せるように改善
-- 🆕 **コマンド機能強化**: `/character new`、`/scene dialogue 佐藤明日香 緊張`など、引数付きコマンドに対応
-- 🆕 **ドキュメント更新**: QUICK_START.mdとWORKSPACE_GUIDE.mdにコマンド例を追加
+- 🆕 **Claude Code v1.0.25 Support**: Improved slash commands to accept arguments.
+- 🆕 **Enhanced Command Functionality**: Supports commands with arguments like `/character new`, `/scene dialogue Asuka Sato tense`.
+- 🆕 **Document Updates**: Added command examples to QUICK_START.md and WORKSPACE_GUIDE.md.
 
-### v0.0.2の機能
-- **ワークスペース管理機能**: 個人の作品を安全に管理できる`.gitignore`設定
-- **動機ベースのキャラクター作成**: 「何をしたい人なのか」から始める新しいアプローチ
-- **Claude統合コマンド**: `/character`、`/story`、`/scene`などの専用コマンド
+### v0.0.2 Features
+- **Workspace Management**: `.gitignore` settings to safely manage individual works.
+- **Motivation-Based Character Creation**: A new approach starting from "What does this person want to do?"
+- **Claude Integrated Commands**: Dedicated commands like `/character`, `/story`, `/scene`.
 
-## 🎯 このプロジェクトが解決する課題
+## 🎯 Problems This Project Solves
 
-- **キャラクターの一貫性崩壊**: AIが文脈を忘れ、キャラクターの性格が変わってしまう
-- **物理的な矛盾**: 場所や時間の整合性が取れなくなる
-- **感情の不自然な変化**: 唐突な心変わりや説明のない感情変化
-- **中だるみする物語**: 構成の甘さによる読者離れ
+- **Character Consistency Collapse**: AI forgets context, leading to changes in character personality.
+- **Physical Contradictions**: Loss of consistency in locations and timelines.
+- **Unnatural Emotional Changes**: Sudden changes of heart or unexplained emotional shifts.
+- **Saggy Middle Stories**: Reader disengagement due to weak plot structure.
 
-## 🚀 特徴
+## 🚀 Features
 
-### 1. 3層構造キャラクター設定
-- **不変コア**: 物語を通じて絶対に変わらない価値観
-- **準安定層**: 状況により変化するが一定範囲内の要素
-- **可変層**: シーンに応じて柔軟に変更可能な要素
+### 1. 3-Layer Character Structure
+- **Invariant Core**: Values that absolutely do not change throughout the story.
+- **Semi-Stable Layer**: Elements that change depending on the situation but within a certain range.
+- **Variable Layer**: Elements that can be flexibly changed according to the scene.
 
-### 2. 段階的物語構築
-- **Phase 1**: 骨組み（スケルトン）の作成
-- **Phase 2**: 重要シーンの特定
-- **Phase 3**: シーンの詳細設計
+### 2. Phased Story Construction
+- **Phase 1**: Skeleton creation.
+- **Phase 2**: Identification of important scenes.
+- **Phase 3**: Detailed scene design.
 
-### 3. 5軸品質評価
-- キャラクター一貫性
-- 物理的論理性
-- 心理的自然さ
-- 読みやすさ
-- 感情的インパクト
+### 3. 5-Axis Quality Evaluation
+- Character consistency
+- Physical logic
+- Psychological naturalness
+- Readability
+- Emotional impact
 
-## 📁 プロジェクト構造
+## 📁 Project Structure
 
 ```
 ai-story-forge/
-├── character-template/     # キャラクターテンプレート
-│   ├── CHARACTER.md       # メインテンプレート
+├── character-template/     # Character templates
+│   ├── CHARACTER.md       # Main template
 │   ├── character-prompts.md
 │   ├── examples/
 │   └── tips.md
-├── story-template/        # 物語作成テンプレート
+├── story-template/        # Story creation templates
 │   ├── STORY.md
 │   ├── story-prompts.md
 │   ├── examples/
 │   └── techniques.md
-├── quality-check/         # 品質チェック
+├── quality-check/         # Quality check
 │   ├── checklist.md
 │   └── common-problems.md
-└── resources/            # 参考資料
+└── resources/            # Reference materials
     ├── principles.md
     ├── constraints.md
     └── workflow.md
 ```
 
-## 🏃‍♂️ クイックスタート
+## 🏃‍♂️ Quick Start
 
-5分で始められます！詳細は[QUICK_START.md](./QUICK_START.md)をご覧ください。
+Get started in 5 minutes! See [QUICK_START.md](./QUICK_START.md) for details.
 
-1. リポジトリをクローン
-2. `character-template/CHARACTER.md`をコピー
-3. 基本情報を記入
-4. プロンプト集を使ってAIと対話
-5. 物語の執筆開始
+1. Clone the repository.
+2. Copy `character-template/CHARACTER.md`.
+3. Fill in basic information.
+4. Interact with AI using the prompt collection.
+5. Start writing your story.
 
-作品の管理方法については[WORKSPACE_GUIDE.md](./WORKSPACE_GUIDE.md)をご覧ください。
+For information on how to manage your work, please see [WORKSPACE_GUIDE.md](./WORKSPACE_GUIDE.md).
 
-## 💡 使用例
+## 💡 Usage Example
 
-### キャラクター作成の例
+### Character Creation Example
 
 ```markdown
-# キャラクター設定書
+# Character Setting Sheet
 
-## 基本情報
-**名前**: 佐藤 明日香
-**年齢**: 28歳
-**職業**: 図書館司書
-**一言で表すと**: 「本を通じて人々の心を繋ぐ、静かな情熱家」
+## Basic Information
+**Name**: Asuka Sato
+**Age**: 28
+**Occupation**: Librarian
+**In a nutshell**: "A quiet enthusiast who connects people's hearts through books."
 
-## 第1層：不変コア
-### 核となる価値観
-**「知識を共有することで、人々の可能性を広げたい」**
+## Layer 1: Invariant Core
+### Core Value
+**"I want to expand people's potential by sharing knowledge."**
 ```
 
-## 🎓 プロンプトエンジニアリング5原則
+## 🎓 5 Principles of Prompt Engineering
 
-本プロジェクトは以下の原則に基づいています：
+This project is based on the following principles:
 
-1. **明確性の原則**: 曖昧さを排除し、具体的な指示を与える
-2. **制約活用の原則**: LLMの限界を理解し、それを前提とした設計
-3. **段階的構築の原則**: 複雑なタスクを小さなステップに分解
-4. **文脈保持の原則**: 重要な情報を適切に配置し、一貫性を保つ
-5. **検証可能性の原則**: 出力の品質を客観的に評価できる仕組み
+1. **Principle of Clarity**: Eliminate ambiguity and give specific instructions.
+2. **Principle of Constraint Utilization**: Understand the limits of LLMs and design accordingly.
+3. **Principle of Incremental Construction**: Break down complex tasks into small steps.
+4. **Principle of Context Retention**: Place important information appropriately to maintain consistency.
+5. **Principle of Verifiability**: A mechanism to objectively evaluate the quality of output.
 
+## 📈 Effective Usage
 
-## 📈 効果的な使い方
+### Week 1: Character Establishment
+- Create CHARACTER.md (30 min)
+- Interact with AI in 5 steps (30 min)
+- Consistency check (15 min)
 
-### Week 1: キャラクター確立
-- CHARACTER.mdを作成（30分）
-- 5ステップでAIと対話（30分）
-- 一貫性チェック（15分）
+### Week 2: Story Construction
+- Create STORY.md Phase 1 (30 min)
+- Identify important scenes (30 min)
+- Detail one scene (45 min)
 
-### Week 2: 物語構築
-- STORY.md Phase1作成（30分）
-- 重要シーンの特定（30分）
-- 1シーンを詳細に（45分）
+### Week 3: Writing and Improvement
+- Write each scene (1 hour per scene)
+- Quality check (15 min each)
+- Final adjustments with a full read-through
 
-### Week 3: 執筆と改善
-- 各シーン執筆（1シーン1時間）
-- 品質チェック（各15分）
-- 通し読みで最終調整
+## 🤝 Contribution
 
-## 🤝 コントリビューション
+This project welcomes contributions from everyone exploring creative collaboration between AI and humans.
 
-このプロジェクトは、AIと人間の創造的な協働を探求する全ての方の貢献を歓迎します。
+- Bug reports/feature suggestions: [Issues](https://github.com/nwiizo/ai-story-forge/issues)
+- Pull requests: Template improvements, addition of new examples, etc.
 
-- バグ報告・機能提案: [Issues](https://github.com/nwiizo/ai-story-forge/issues)
-- プルリクエスト: テンプレートの改善、新しい例の追加など
-
-## 📋 更新履歴
+## 📋 Update History
 
 ### v0.0.2 (2025-06-29)
-- ワークスペース管理機能の追加
-- `.gitignore`による個人作品の保護
-- ワークスペースガイドの作成
+- Added workspace management function.
+- Protection of personal works with `.gitignore`.
+- Created workspace guide.
 
 ### v0.0.1 (2025-06-29)
-- 初回リリース
-- 基本テンプレートシステム
-- Claude統合コマンド
-- 動機ベースのキャラクター作成
+- Initial release.
+- Basic template system.
+- Claude integrated commands.
+- Motivation-based character creation.
 
-## 📜 ライセンス
+## 📜 License
 
-このプロジェクトはMITライセンスの下で公開されています。
+This project is released under the MIT License.
 
-## 🙏 謝辞
+## 🙏 Acknowledgements
 
-このプロジェクトは、プロンプトエンジニアリングと物語創作の分野で活躍する多くの先駆者たちの知見に深く影響を受けています。
-
-AI技術の可能性を探求し続ける研究者の皆様、物語構造やキャラクター造形の理論を体系化してきた作家・脚本家の皆様、そしてAIと人間の創造的な協働という新しい領域を開拓し続けるすべての実践者に心から感謝いたします。
-
-このプロジェクトが、次世代の物語創作者たちの一助となることを願っています。
+This project is influenced by pioneers in prompt engineering and story creation. We thank researchers, writers, and practitioners in AI and storytelling. We hope this project aids future story creators.
 
 ---
 
-**「制約を創造性に変える」** - それがAI Story Forgeの理念です。
+**"Turning constraints into creativity"** - That is the philosophy of AI Story Forge.

--- a/WORKSPACE_GUIDE.md
+++ b/WORKSPACE_GUIDE.md
@@ -1,74 +1,74 @@
-# ワークスペースガイド - 作品の管理方法
+# Workspace Guide - How to Manage Your Works
 
-## 推奨ディレクトリ構造
+## Recommended Directory Structure
 
-AI Story Forgeを使って作成した作品は、以下のような構造で管理することをお勧めします。これらのディレクトリは`.gitignore`で除外されているため、誤ってコミットされることはありません。
+It is recommended to manage works created using AI Story Forge with the following structure. These directories are excluded by `.gitignore`, so they will not be accidentally committed.
 
 ```
 ai-story-forge/
-├── my-characters/              # 作成したキャラクター
-│   ├── 2025-06-protagonist/    # 日付-役割で整理
+├── my-characters/              # Created characters
+│   ├── 2025-06-protagonist/    # Organized by date-role
 │   │   ├── tanaka-misaki.character.md
 │   │   └── notes.md
 │   └── 2025-06-supporting/
 │       ├── yamada-taro.character.md
 │       └── suzuki-hanako.character.md
 │
-├── my-stories/                 # 作成した物語
-│   ├── last-letter/           # 作品ごとにフォルダ
-│   │   ├── story.md           # メインストーリー
-│   │   ├── outline.md         # プロット
-│   │   ├── scenes/            # 個別シーン
+├── my-stories/                 # Created stories
+│   ├── last-letter/           # Folder per work
+│   │   ├── story.md           # Main story
+│   │   ├── outline.md         # Plot
+│   │   ├── scenes/            # Individual scenes
 │   │   │   ├── scene-01-meeting.md
 │   │   │   └── scene-02-revelation.md
-│   │   └── quality-checks/    # 品質評価記録
+│   │   └── quality-checks/    # Quality evaluation records
 │   └── digital-ghost/
 │       ├── story.md
 │       ├── chapters/
 │       │   ├── chapter-01.md
 │       │   └── chapter-02.md
-│       └── character-refs/    # この物語用のキャラ設定
+│       └── character-refs/    # Character settings for this story
 │
-├── drafts/                    # 作業中・下書き
+├── drafts/                    # Work in progress/drafts
 │   ├── ideas.md
 │   ├── experimental-scene.md
 │   └── dialogue-practice.md
 │
-└── personal-notes/            # 個人的なメモ
+└── personal-notes/            # Personal notes
     ├── writing-tips.md
     ├── favorite-prompts.md
     └── my-motivation-list.md
 ```
 
-## ファイル命名規則
+## File Naming Conventions
 
-### キャラクターファイル
-- `[名前].character.md` - 例: `tanaka-misaki.character.md`
-- `[名前]-[バージョン].character.md` - 例: `tanaka-misaki-v2.character.md`
+### Character Files
+- `[name].character.md` - Example: `tanaka-misaki.character.md`
+- `[name]-[version].character.md` - Example: `tanaka-misaki-v2.character.md`
 
-### 物語ファイル
-- `[タイトル].story.md` - 例: `last-letter.story.md`
-- `scene-[番号]-[内容].md` - 例: `scene-03-confession.md`
-- `chapter-[番号].md` - 例: `chapter-01.md`
+### Story Files
+- `[title].story.md` - Example: `last-letter.story.md`
+- `scene-[number]-[content].md` - Example: `scene-03-confession.md`
+- `chapter-[number].md` - Example: `chapter-01.md`
 
-### 作業ファイル
-- `[日付]-[内容].draft.md` - 例: `2025-06-15-opening.draft.md`
-- `[内容].wip.md` - 例: `climax-scene.wip.md`
+### Work Files
+- `[date]-[content].draft.md` - Example: `2025-06-15-opening.draft.md`
+- `[content].wip.md` - Example: `climax-scene.wip.md`
 
-## 作品の整理のコツ
+## Tips for Organizing Works
 
-### 1. 日付での管理
+### 1. Management by Date
 ```
 my-characters/
-├── 2025-06/     # 月ごとに整理
+├── 2025-06/     # Organize by month
 ├── 2024-02/
-└── archive/      # 古い作品
+└── archive/      # Old works
 ```
 
-### 2. プロジェクトごとの管理
+### 2. Management by Project
 ```
 my-stories/
-├── project-mystery-novel/    # プロジェクト名
+├── project-mystery-novel/    # Project name
 │   ├── characters/
 │   ├── plot/
 │   └── scenes/
@@ -77,8 +77,8 @@ my-stories/
     └── story-02/
 ```
 
-### 3. バージョン管理
-重要な作品は個別のGitリポジトリで管理することも検討してください：
+### 3. Version Control
+Consider managing important works in individual Git repositories:
 ```bash
 cd my-stories/important-novel
 git init
@@ -86,93 +86,93 @@ git add .
 git commit -m "Initial draft"
 ```
 
-## セキュリティとバックアップ
+## Security and Backup
 
-### 重要な作品のバックアップ
-1. **クラウドストレージ**: Google Drive、Dropbox等に定期的にバックアップ
-2. **個別リポジトリ**: 重要な作品は別のプライベートリポジトリで管理
-3. **エクスポート**: 定期的にPDFやWord形式でエクスポート
+### Backing Up Important Works
+1. **Cloud Storage**: Regularly back up to Google Drive, Dropbox, etc.
+2. **Individual Repositories**: Manage important works in separate private repositories.
+3. **Export**: Regularly export in PDF or Word format.
 
-### プライバシーの確保
-- 個人的な設定や実在の人物をモデルにしたキャラクターは、特に注意して管理
-- 必要に応じて暗号化ツールの使用を検討
+### Ensuring Privacy
+- Manage personal settings and characters modeled on real people with particular care.
+- Consider using encryption tools if necessary.
 
-## Claude Codeコマンド使用時の保存先
+## Save Destination when using Claude Code Commands
 
-### コマンドの引数指定
+### Specifying Command Arguments
 
-Claude Code v1.0.25以降では、コマンドに引数を渡すことができます：
+With Claude Code v1.0.25 and later, you can pass arguments to commands:
 
 ```bash
-# キャラクター作成（引数付き）
-/character new                      # 新規作成（対話形式）
-/character develop 田中美咲          # 特定キャラクターの深化
-/character check 佐藤明日香          # 一貫性チェック
-/character dialogue 山田太郎         # 対話シミュレーション
-# → 保存先: my-characters/2025-06/[character-name].character.md
+# Character creation (with arguments)
+/character new                      # Create new (interactive)
+/character develop Misaki Tanaka    # Deepen a specific character
+/character check Asuka Sato         # Check consistency
+/character dialogue Taro Yamada     # Dialogue simulation
+# → Save destination: my-characters/2025-06/[character-name].character.md
 
-# 物語作成（引数付き）
-/story plot "最後の手紙"           # タイトル指定で構築
-/story structure "デジタルの亡霊"   # 構成作成
-/story theme "人間とAIの共存"      # テーマから構築
-# → 保存先: my-stories/[story-title]/story.md
+# Story creation (with arguments)
+/story plot "The Last Letter"         # Construct by title
+/story structure "Digital Ghost"    # Create structure
+/story theme "Human-AI Coexistence" # Construct from theme
+# → Save destination: my-stories/[story-title]/story.md
 
-# シーン作成（引数付き）
-/scene dialogue 佐藤明日香 緊張      # 会話シーン（キャラと雰囲気指定）
-/scene emotion 田中美咲 懐かしさ 800   # 感情描写（文字数指定）
-/scene action 緊迫                 # アクションシーン
-# → 保存先: my-stories/[story-title]/scenes/scene-XX.md
+# Scene creation (with arguments)
+/scene dialogue Asuka Sato tense    # Dialogue scene (specify character and atmosphere)
+/scene emotion Misaki Tanaka nostalgic 800 # Emotion depiction (specify character count)
+/scene action suspenseful           # Action scene
+# → Save destination: my-stories/[story-title]/scenes/scene-XX.md
 
-# 品質チェック（引数付き）
-/quality scene "手紙の発見" --detail     # 詳細評価
-/quality character 佐藤明日香 --fix      # 修正案付き
-/quality story "最後の手紙" --compare   # 比較分析
-# → 保存先: my-stories/[story-title]/quality-checks/check-[date].md
+# Quality check (with arguments)
+/quality scene "Discovery of the letter" --detail # Detailed evaluation
+/quality character Asuka Sato --fix     # With revision suggestions
+/quality story "The Last Letter" --compare # Comparative analysis
+# → Save destination: my-stories/[story-title]/quality-checks/check-[date].md
 
-# 会話作成（引数付き）
-/dialogue first-meet 佐藤明日香 山田太郎  # 初対面の会話
-/dialogue conflict 美咲 息子 --mood 緊張   # 対立シーン
-/dialogue confession --subtext       # 告白（言外の意味重視）
-# → 保存先: my-stories/[story-title]/scenes/scene-XX-dialogue.md
+# Conversation creation (with arguments)
+/dialogue first-meet Asuka Sato Taro Yamada # First meeting conversation
+/dialogue conflict Misaki Son --mood tense  # Conflict scene
+/dialogue confession --subtext      # Confession (emphasize subtext)
+# → Save destination: my-stories/[story-title]/scenes/scene-XX-dialogue.md
 ```
 
-### 推奨保存先のまとめ
+### Summary of Recommended Save Destinations
 
-## テンプレートからの作業開始
+## Starting Work from a Template
 
 ```bash
-# キャラクターテンプレートをコピーして開始
+# Copy character template to start
 cp character-template/CHARACTER.md my-characters/new-character.character.md
 
-# Claude Codeで編集
+# Edit with Claude Code
 /character develop new-character
 
-# 物語テンプレートをコピーして開始
+# Copy story template to start
 cp story-template/STORY.md my-stories/new-story/story.md
 
-# Claude Codeで構築
+# Construct with Claude Code
 /story develop new-story
 ```
 
-## 効率的なワークフロー
+## Efficient Workflow
 
-### 新作品の開始
-1. キャラクター作成： `/character new`
-2. キャラクターの一貫性確認： `/character check [名前]`
-3. 物語構築： `/story plot "[タイトル]"`
-4. 重要シーン作成： `/scene [タイプ] [オプション]`
-5. 品質チェック： `/quality story "[タイトル]" --detail`
+### Starting a New Work
+1. Create character: `/character new`
+2. Check character consistency: `/character check [name]`
+3. Construct story: `/story plot "[title]"`
+4. Create important scenes: `/scene [type] [options]`
+5. Quality check: `/quality story "[title]" --detail`
 
-### 既存作品の改善
-1. 現状評価： `/quality story "[タイトル]"`
-2. 問題点の修正： `/quality scene "[シーン名]" --fix`
-3. キャラクター調整： `/character develop [名前]`
-4. 会話の改善： `/dialogue [タイプ] [キャラクター]`
+### Improving an Existing Work
+1. Evaluate current state: `/quality story "[title]"`
+2. Correct problems: `/quality scene "[scene_name]" --fix`
+3. Adjust character: `/character develop [name]`
+4. Improve conversation: `/dialogue [type] [character]`
 
 ---
 
-💡 **ヒント**: 
-- 作品フォルダは定期的に整理しましょう
-- 完成した作品は`archive`フォルダに移動
-- お気に入りのプロンプトは`personal-notes`に保存して再利用
-- Claude Codeのコマンド引数を活用して効率化
+💡 **Tips**:
+- Organize your work folders regularly
+- Move completed works to an `archive` folder
+- Save favorite prompts in `personal-notes` for reuse
+- Utilize Claude Code command arguments for efficiency

--- a/character-template/CHARACTER.md
+++ b/character-template/CHARACTER.md
@@ -1,136 +1,136 @@
-# キャラクター設定書
+# Character Setting Sheet
 
-## 基本情報
-**名前**：  
-**年齢**：  
-**性別**：  
-**職業**：  
-**一言で表すと**：  
-
----
-
-## 身上調査書（キャラクターの輪郭）
-### 基本データ
-- **身長・体重**：  
-- **出身地**：  
-- **家族構成**：  
-- **学歴・経歴**：  
-
-### 内面的要素
-- **好きなもの**（音楽・食べ物・場所など）：  
-- **苦手なもの**：  
-- **尊敬する人**：  
-- **恐怖（何を怖いと思うか）**：  
-- **将来の夢**：  
-- **特技・趣味**：  
-
-### 生活習慣
-- **住んでいる場所**：  
-- **日課**：  
-- **口癖**：  
-- **服装の好み**：  
+## Basic Information
+**Name**:
+**Age**:
+**Gender**:
+**Occupation**:
+**In a nutshell**:
 
 ---
 
-## 第1層：不変コア（物語を通じて絶対に変わらない要素）
+## Personal History (Character Outline)
+### Basic Data
+- **Height/Weight**:
+- **Birthplace**:
+- **Family Structure**:
+- **Education/Career**:
 
-### 0. 行動の動機（最重要：これを最初に決める）
-**「何をしたい人なのか」**：  
+### Internal Elements
+- **Likes** (music, food, places, etc.):
+- **Dislikes**:
+- **Person they respect**:
+- **Fears (What do they find scary?)**:
+- **Future dreams**:
+- **Special skills/Hobbies**:
 
-この動機を選んだ理由：  
-- 読者の共感ポイント：  
-- この動機から生まれる行動：  
+### Lifestyle Habits
+- **Place of residence**:
+- **Daily routine**:
+- **Catchphrases**:
+- **Clothing preferences**:
 
-### 1. 核となる価値観（動機を支える信念）
-**「」**
+---
 
-なぜこれが最も大切なのか：  
+## Layer 1: Immutable Core (Elements that absolutely do not change throughout the story)
+
+### 0. Motivation for Action (Most important: Decide this first)
+**"What does this person want to do?"**:
+
+Reason for choosing this motivation:
+- Reader's empathy point:
+- Actions arising from this motivation:
+
+### 1. Core Value (Belief supporting the motivation)
+**" "**
+
+Why is this most important?:
 
 
-### 2. 最大の恐れ（価値観の裏返し）
-**「」**
+### 2. Greatest Fear (Flip side of the value)
+**" "**
 
-この恐れが行動にどう影響するか：  
+How does this fear affect behavior?:
 
 
-### 3. 根本的矛盾（人間らしさの源）
-**価値観「」 vs 内なる欲求「」**
+### 3. Fundamental Contradiction (Source of human-likeness)
+**Value " " vs. Inner Desire " "**
 
-この矛盾が生む葛藤：  
+Conflict arising from this contradiction:
 
 
 ---
 
-## 第2層：準安定層（状況で変化するが一定の範囲内）
+## Layer 2: Semi-stable Layer (Changes with the situation but within a certain range)
 
-### 1. 感情の基本パターン
-- **平常時**：  
-- **ストレス時**：  
-- **幸福時**：  
+### 1. Basic Emotional Patterns
+- **Normal state**:
+- **Under stress**:
+- **When happy**:
 
-### 2. 人間関係の型
-- **信頼する相手への態度**：  
-- **初対面の相手への態度**：  
-- **苦手な相手への態度**：  
+### 2. Types of Human Relationships
+- **Attitude towards trusted individuals**:
+- **Attitude towards new acquaintances**:
+- **Attitude towards disliked individuals**:
 
-### 3. 成長の方向性
-- **現在の段階**：  
-- **目指す方向**：  
-
----
-
-## 第3層：可変層（シーンに応じて柔軟に変更可能）
-
-### 1. 話し方の特徴
-**基本的なトーン**：  
-**よく使う言葉**：
-- 「」
-- 「」
-- 「」
-
-**使わない言葉**：  
-
-### 2. 行動パターン（上位3つ）
-1. ＿＿な状況では、＿＿する
-2. ＿＿な状況では、＿＿する  
-3. ＿＿な状況では、＿＿する
-
-### 3. 特徴的な仕草・癖
-- 考える時：  
-- 緊張した時：  
-- 嬉しい時：  
+### 3. Direction of Growth
+- **Current stage**:
+- **Aspired direction**:
 
 ---
 
-## キャラクターの「芯」（絶対にブレてはいけない部分）
+## Layer 3: Variable Layer (Can be flexibly changed according to the scene)
 
-### 守るべき「らしさ」
-- このキャラクターが絶対にしないこと：  
-- このキャラクターが必ずすること：  
-- 読者を裏切らないための約束：  
+### 1. Speech Characteristics
+**Basic tone**:
+**Frequently used words**:
+- " "
+- " "
+- " "
 
-### 変えていい部分
-- 状況に応じて調整可能な要素：  
-- ストーリーの展開で発展させられる部分：  
-- ライブ感覚で軌道修正できる範囲：  
+**Words not used**:
+
+### 2. Behavior Patterns (Top 3)
+1. In a ______ situation, they ______
+2. In a ______ situation, they ______
+3. In a ______ situation, they ______
+
+### 3. Characteristic Gestures/Habits
+- When thinking:
+- When nervous:
+- When happy:
 
 ---
 
-## 一貫性チェックポイント
-- [ ] すべての行動は「動機」から説明できるか？
-- [ ] 動機と価値観は矛盾していないか？
-- [ ] 矛盾は意図的で、人間味を生んでいるか？
-- [ ] キャラクターの「芯」は守られているか？
-- [ ] 成長・変化は自然で段階的か？
+## Character's "Core" (Parts that must not be blurred)
+
+### "Likeness" to be protected
+- Things this character will never do:
+- Things this character will always do:
+- Promises to the reader not to betray:
+
+### Parts that can be changed
+- Elements adjustable according to the situation:
+- Parts that can be developed with the story's progression:
+- Range for live adjustments:
 
 ---
 
-## メモ・補足
-（自由記述欄）
+## Consistency Checkpoints
+- [ ] Can all actions be explained by "motivation"?
+- [ ] Are motivation and values not contradictory?
+- [ ] Is the contradiction intentional and does it create human-likeness?
+- [ ] Is the character's "core" protected?
+- [ ] Is growth/change natural and gradual?
+
+---
+
+## Notes/Supplements
+(Free description field)
 
 
-## 作成のヒント
-1. **動機を最初に決める**：性格をあれこれ考える前に「何をしたい人なのか」を明確に
-2. **身上調査書は30分で**：あまり深く考えすぎず、直感的に埋める
-3. **既存キャラの真似は厳禁**：どんなに人気があっても真似をしない
-4. **動機リストを作る**：自分なりの動機パターンを蓄積していく
+## Creation Hints
+1. **Decide motivation first**: Clarify "What does this person want to do?" before thinking about personality details.
+2. **Personal history in 30 minutes**: Don't overthink it, fill it in intuitively.
+3. **Strictly no imitation of existing characters**: No matter how popular, do not imitate.
+4. **Create a motivation list**: Accumulate your own motivation patterns.

--- a/character-template/character-prompts.md
+++ b/character-template/character-prompts.md
@@ -1,225 +1,225 @@
-# キャラクター作成プロンプト集
+# Character Creation Prompt Collection
 
-## 動機ベースのキャラクター作成法
+## Motivation-Based Character Creation Method
 
-### Step 0: 動機リストの作成
+### Step 0: Create a Motivation List
 ```
-以下のカテゴリーで、読者の共感を呼ぶ動機を5つずつ挙げてください：
+For each of the following categories, list five motivations that resonate with readers:
 
-1. 個人的な成長に関する動機
-2. 他者との関係に関する動機
-3. 社会的な目標に関する動機
-4. 内面的な探求に関する動機
-5. 特別な使命に関する動機
+1. Motivations related to personal growth
+2. Motivations related to relationships with others
+3. Motivations related to social goals
+4. Motivations related to inner exploration
+5. Motivations related to a special mission
 
-特に「勇気」を必要とする動機を含めてください。
-```
-
-### 動機の深掘り
-```
-選んだ動機：[例：大切な人を守りたい]
-
-この動機について：
-1. なぜこれが強い共感を呼ぶのか
-2. この動機から生まれる具体的な行動3つ
-3. この動機が試される状況3つ
-4. この動機の裏にある恐れ
-5. この動機を持つに至った背景
+Please especially include motivations that require "courage."
 ```
 
-### 動機からキャラクターへ
+### Deep Dive into Motivation
 ```
-動機：[選んだ動機]
+Chosen motivation: [Example: I want to protect someone important]
 
-この動機を持つ人物の：
-1. 日常的な行動パターン
-2. 判断の基準
-3. 他者との関わり方
-4. 弱点と限界
-5. 成長の可能性
-```
-
-## 基本の5ステップ作成法
-
-### Step 1: 核となる価値観を決める
-```
-次の人物の最も大切にしている価値観を1つだけ設定してください。
-
-[基本設定]
-- 年齢：
-- 職業：
-- 環境：
-
-条件：
-- 具体的で行動の指針となるもの
-- その人の人生の軸となるもの
-- 「○○を通じて△△したい」の形式で
+Regarding this motivation:
+1. Why does this resonate strongly with people?
+2. Three specific actions arising from this motivation
+3. Three situations where this motivation is tested
+4. The fear behind this motivation
+5. The background leading to having this motivation
 ```
 
-### Step 2: 価値観から恐れを導く
+### From Motivation to Character
 ```
-「[Step1の価値観]」を最も大切にする人が、
-最も恐れることは何でしょうか？
+Motivation: [Chosen motivation]
 
-価値観が脅かされる状況を具体的に。
-```
-
-### Step 3: 人間的な矛盾を加える
-```
-価値観：[Step1の内容]
-恐れ：[Step2の内容]
-
-この人物に内在する、価値観と矛盾する欲求や性質を1つ加えてください。
-この矛盾が物語に深みを与えます。
+For a person with this motivation:
+1. Daily behavior patterns
+2. Criteria for judgment
+3. How they interact with others
+4. Weaknesses and limitations
+5. Potential for growth
 ```
 
-### Step 4: 具体的な行動パターン
+## Basic 5-Step Creation Method
+
+### Step 1: Determine the Core Value
 ```
-設定：
-- 価値観：[Step1]
-- 恐れ：[Step2]  
-- 矛盾：[Step3]
+Please set only one most important value for the following person.
 
-この人物の典型的な行動パターンを3つ挙げてください。
-「○○な時、××する」の形式で。
-```
+[Basic Settings]
+- Age:
+- Occupation:
+- Environment:
 
-### Step 5: 話し方と仕草
-```
-[これまでの設定まとめ]
-
-この人物の：
-1. 話し方の特徴
-2. よく使う口癖（2-3個）
-3. 特徴的な仕草
-
-を設定してください。内面が表れるように。
+Conditions:
+- Specific and action-guiding
+- Something that forms the axis of their life
+- In the format "I want to △△ through ○○"
 ```
 
-## 応用テクニック
-
-### 赤ずきん原則：ニュース記事形式
+### Step 2: Derive Fear from Value
 ```
-[キャラクター基本設定]について、
-地方新聞の人物紹介記事（300字程度）を書いてください。
+What would a person who cherishes "[Value from Step 1]" most,
+fear the most?
 
-【見出し】
-【本文】日常のエピソード、周囲の評判、本人の言葉を含める
+Describe a specific situation where this value is threatened.
 ```
 
-### 赤ずきん原則：インタビュー形式  
+### Step 3: Add a Human Contradiction
 ```
-[キャラクター名]への5問5答のインタビューを作成してください。
+Value: [Content of Step 1]
+Fear: [Content of Step 2]
 
-Q1: 今の仕事を選んだ理由は？
+Please add one desire or characteristic inherent in this person that contradicts their value.
+This contradiction will add depth to the story.
+```
+
+### Step 4: Specific Behavior Patterns
+```
+Settings:
+- Value: [Step 1]
+- Fear: [Step 2]
+- Contradiction: [Step 3]
+
+List three typical behavior patterns for this person.
+In the format "When ______, they ______."
+```
+
+### Step 5: Speech Style and Mannerisms
+```
+[Summary of settings so far]
+
+For this person:
+1. Characteristics of their speech style
+2. Frequently used catchphrases (2-3)
+3. Characteristic mannerisms
+
+Please set these. Make sure they reflect their inner self.
+```
+
+## Applied Techniques
+
+### Little Red Riding Hood Principle: News Article Format
+```
+Regarding [Basic Character Settings],
+please write a personality profile article (around 300 characters) for a local newspaper.
+
+【Headline】
+【Body】Include daily episodes, reputation among peers, and the person's own words.
+```
+
+### Little Red Riding Hood Principle: Interview Format
+```
+Please create a 5-question, 5-answer interview with [Character Name].
+
+Q1: Why did you choose your current job?
 A1: 
 
-Q2: 大切にしていることは？
+Q2: What do you cherish?
 A2:
 
-Q3: 休日の過ごし方は？
+Q3: How do you spend your holidays?
 A3:
 
-Q4: 最近嬉しかったことは？
+Q4: What made you happy recently?
 A4:
 
-Q5: 将来の夢は？
+Q5: What is your future dream?
 A5:
 
-（人物像が立体的に見える質問を選ぶ）
+(Choose questions that make the character appear three-dimensional)
 ```
 
-### 感情マッピング
+### Emotion Mapping
 ```
-[キャラクター設定]
+[Character Settings]
 
-この人物の感情反応をマッピングしてください：
+Please map this person's emotional responses:
 
-【喜び】→ どんな表現をするか
-【怒り】→ どんな行動を取るか
-【悲しみ】→ どう対処するか
-【恐れ】→ 何を最も恐れるか
-【驚き】→ どんな反応を示すか
+【Joy】→ How do they express it?
+【Anger】→ What actions do they take?
+【Sadness】→ How do they cope?
+【Fear】→ What do they fear most?
+【Surprise】→ How do they react?
 
-各感情での特徴的な言動を1つずつ。
-```
-
-### 関係性ダイナミクス
-```
-[キャラクターA]と[キャラクターB]の関係性を設定してください。
-
-1. 出会いのきっかけ
-2. 互いの第一印象
-3. 現在の関係性
-4. 相手に対する本音
-5. この関係が生む物語の可能性
-
-両者の価値観の違いが生む化学反応を重視。
+One characteristic behavior for each emotion.
 ```
 
-## プロンプトのカスタマイズ
-
-### ジャンル別調整
-
-**ミステリー向け**
+### Relationship Dynamics
 ```
-このキャラクターが持つ「秘密」を1つ設定してください。
-- 本人も気づいていない秘密
-- 物語の鍵となる秘密
-- 価値観と関連する秘密
-```
+Please set the relationship between [Character A] and [Character B].
 
-**恋愛小説向け**
-```
-このキャラクターの恋愛観を設定してください。
-- 理想の相手像
-- 恋愛における弱点
-- 過去の恋愛経験が与えた影響
+1. How they met
+2. Their first impressions of each other
+3. Current relationship
+4. True feelings towards the other person
+5. Story possibilities arising from this relationship
+
+Emphasize the chemical reaction created by the differences in their values.
 ```
 
-**ファンタジー向け**
-```
-このキャラクターの特殊能力を設定してください。
-- 能力の内容
-- 能力の制限・代償
-- 能力と価値観の関係
-```
+## Prompt Customization
 
-## トラブルシューティング
+### Genre-Specific Adjustments
 
-### キャラクターが平板な時
+**For Mystery**
 ```
-このキャラクターに「でも」を3つ加えてください。
-
-例：
-- 優しい、でも○○な時は冷酷
-- 臆病、でも○○のためなら勇敢
-- 論理的、でも○○には感情的
+Please set one "secret" this character has.
+- A secret the character themself is unaware of
+- A secret that is key to the story
+- A secret related to their values
 ```
 
-### 行動原理が不明確な時
+**For Romance Novels**
 ```
-このキャラクターが絶対にしないこと3つと、
-必ずすること3つを挙げてください。
-
-価値観に基づいて具体的に。
-```
-
-### 他キャラとの差別化
-```
-[既存キャラクターリスト]
-
-新キャラクターが既存キャラと被らないよう、
-独自の特徴を3つ設定してください。
+Please set this character's view on love.
+- Ideal partner image
+- Weaknesses in love
+- Impact of past romantic experiences
 ```
 
-## 効果的な使い方
+**For Fantasy**
+```
+Please set this character's special ability.
+- Details of the ability
+- Limitations/costs of the ability
+- Relationship between the ability and their values
+```
 
-1. **順番を守る**: Step 1から順に進むことで自然な深みが生まれる
-2. **具体例を求める**: 抽象的な回答には具体的なエピソードを追加で聞く
-3. **矛盾を恐れない**: 人間らしい矛盾はキャラクターを豊かにする
-4. **反復と洗練**: 一度で完璧を求めず、何度も対話して深める
+## Troubleshooting
+
+### When a Character is Flat
+```
+Please add three "buts" to this character.
+
+Example:
+- Kind, but ruthless when ______
+- Cowardly, but brave for the sake of ______
+- Logical, but emotional about ______
+```
+
+### When the Principle of Action is Unclear
+```
+List three things this character absolutely will not do,
+and three things they absolutely will do.
+
+Be specific, based on their values.
+```
+
+### Differentiating from Other Characters
+```
+[Existing Character List]
+
+Set three unique characteristics for the new character
+to ensure they don't overlap with existing characters.
+```
+
+## Effective Usage
+
+1. **Follow the order**: Proceeding sequentially from Step 1 creates natural depth.
+2. **Request specific examples**: For abstract answers, ask for additional specific episodes.
+3. **Don't fear contradictions**: Human-like contradictions enrich characters.
+4. **Iterate and refine**: Don't aim for perfection in one go; deepen through multiple dialogues.
 
 ---
 
-これらのプロンプトは出発点です。あなたの物語に合わせて自由にカスタマイズしてください。
+These prompts are a starting point. Feel free to customize them to fit your story.

--- a/character-template/examples/detective-example.md
+++ b/character-template/examples/detective-example.md
@@ -1,99 +1,99 @@
-# キャラクター設定書 - 探偵の例
+# Character Setting Sheet - Detective Example
 
-## 基本情報
-**名前**：黒川 誠（くろかわ まこと）  
-**年齢**：42歳  
-**職業**：私立探偵（元警視庁捜査一課）  
-**一言で表すと**：「真実のためなら泥をかぶる、孤高の真実追求者」  
-
----
-
-## 第1層：不変コア（物語を通じて絶対に変わらない要素）
-
-### 1. 核となる価値観（1つだけ）
-**「真実を明らかにすることで、犠牲者に正義をもたらす」**
-
-なぜこれが最も大切なのか：  
-15年前、冤罪で服役した親友が獄中で自殺した。自分が真実を突き止められなかったせいだ。二度と同じ過ちは繰り返さない。たとえ世界を敵に回しても、真実だけは曲げない。
-
-### 2. 最大の恐れ（価値観の裏返し）
-**「自分の過ちで無実の人を傷つけること」**
-
-この恐れが行動にどう影響するか：  
-証拠を何度も検証し、決して早急な結論を出さない。確信が持てるまで、誰も犯人扱いしない。この慎重さが時に事件解決を遅らせることもある。
-
-### 3. 根本的矛盾（人間らしさの源）
-**価値観「真実の追求」 vs 内なる欲求「優しい嘘で人を守りたい」**
-
-この矛盾が生む葛藤：  
-真実が誰かを深く傷つけると分かっていても、それを隠すことはできない。しかし、真実を告げる瞬間、相手の顔を直視できない自分がいる。
+## Basic Information
+**Name**: Makoto Kurokawa
+**Age**: 42
+**Occupation**: Private Detective (Former Metropolitan Police Department First Investigation Division)
+**In a nutshell**: "A solitary seeker of truth who will bear any burden for the sake of truth."
 
 ---
 
-## 第2層：準安定層（状況で変化するが一定の範囲内）
+## Layer 1: Immutable Core (Elements that absolutely do not change throughout the story)
 
-### 1. 感情の基本パターン
-- **平常時**：冷静で観察眼が鋭い。感情を表に出さない  
-- **ストレス時**：煙草の本数が増え、独り言が多くなる  
-- **幸福時**：かすかに口角が上がる程度。幸福を素直に表現できない  
+### 1. Core Value (Only one)
+**"To bring justice to victims by revealing the truth."**
 
-### 2. 人間関係の型
-- **信頼する相手への態度**：多くを語らないが、行動で信頼を示す。危険から守ろうとする  
-- **初対面の相手への態度**：礼儀正しいが距離を置く。相手の嘘を見抜こうとする癖が出る  
-- **苦手な相手への態度**：最小限の接触に留める。できるだけ一人で行動しようとする  
+Why is this most important?:
+15 years ago, his best friend, who was imprisoned for a crime he didn't commit, committed suicide in jail. He blames himself for not being able to uncover the truth. He will not repeat the same mistake. Even if the whole world turns against him, he will not bend the truth.
 
-### 3. 成長の方向性
-- **現在の段階**：真実を追求するあまり、人の感情を軽視しがち  
-- **目指す方向**：真実と共に、人の心も大切にできる探偵になる  
+### 2. Greatest Fear (Flip side of the value)
+**"Hurting an innocent person due to his own mistake."**
 
----
+How does this fear affect behavior?:
+He verifies evidence repeatedly and never rushes to conclusions. He doesn't treat anyone as a criminal until he is certain. This caution sometimes delays case resolution.
 
-## 第3層：可変層（シーンに応じて柔軟に変更可能）
+### 3. Fundamental Contradiction (Source of human-likeness)
+**Value "Pursuit of truth" vs. Inner Desire "Wanting to protect people with kind lies."**
 
-### 1. 話し方の特徴
-**基本的なトーン**：低い声で簡潔に話す。無駄な言葉を使わない  
-**よく使う言葉**：
-- 「事実だけを話してください」
-- 「...そういうことか」
-- 「真実は一つしかない」
-
-**使わない言葉**：感情的な表現、推測に基づく断定（「きっと」「たぶん」）  
-
-### 2. 行動パターン（上位3つ）
-1. 現場では必ず全体を見渡してから細部を観察する
-2. 重要な考察をする時は、煙草を吸いながら窓の外を眺める  
-3. 事件が解決すると、一人で犠牲者の墓参りをする
-
-### 3. 特徴的な仕草・癖
-- 考える時：右手の親指で顎を撫でる  
-- 緊張した時：ポケットの中で古い警察手帳を握る  
-- 嬉しい時：わずかに眉が動く程度で、すぐに表情を戻す  
+Conflict arising from this contradiction:
+Even if he knows the truth will deeply hurt someone, he cannot hide it. However, at the moment of revealing the truth, he finds himself unable to look the other person in the eye.
 
 ---
 
-## 一貫性チェックポイント
-- [x] すべての行動は「核となる価値観」で説明できるか？
-- [x] 矛盾は意図的で、人間味を生んでいるか？
-- [x] 話し方は場面が変わっても統一されているか？
-- [x] 成長・変化は自然で段階的か？
+## Layer 2: Semi-stable Layer (Changes with the situation but within a certain range)
+
+### 1. Basic Emotional Patterns
+- **Normal state**: Calm and observant. Does not show emotions openly.
+- **Under stress**: Smokes more cigarettes, talks to himself more often.
+- **When happy**: Corners of his mouth lift slightly. Cannot express happiness openly.
+
+### 2. Types of Human Relationships
+- **Attitude towards trusted individuals**: Doesn't say much, but shows trust through actions. Tries to protect them from danger.
+- **Attitude towards new acquaintances**: Polite but keeps a distance. Has a habit of trying to see through their lies.
+- **Attitude towards disliked individuals**: Keeps contact to a minimum. Tries to act alone as much as possible.
+
+### 3. Direction of Growth
+- **Current stage**: Tends to disregard people's feelings in his pursuit of truth.
+- **Aspired direction**: To become a detective who can value people's hearts along with the truth.
 
 ---
 
-## メモ・補足
-- 愛用品：亡き親友の形見のライター（禁煙しようとするが、このライターを手放せない）
-- 特技：相手の嘘を見抜く（視線、仕草、声のトーンから）
-- 弱点：子供に対して甘い（亡くなった親友に幼い娘がいた）
-- 日課：毎朝5時に起きて、1時間のランニング（頭を整理する時間）
+## Layer 3: Variable Layer (Can be flexibly changed according to the scene)
 
-### 物語での使用例
-**シーン設定**：依頼人が嘘をついていることに気づいた場面
+### 1. Speech Characteristics
+**Basic tone**: Speaks concisely in a low voice. Avoids unnecessary words.
+**Frequently used words**:
+- "Please state only the facts."
+- "...So that's it."
+- "There is only one truth."
+
+**Words not used**: Emotional expressions, assertions based on speculation ("surely," "probably").
+
+### 2. Behavior Patterns (Top 3)
+1. Always surveys the entire scene before observing details.
+2. When making important considerations, he smokes a cigarette while looking out the window.
+3. When a case is solved, he visits the victim's grave alone.
+
+### 3. Characteristic Gestures/Habits
+- When thinking: Strokes his chin with his right thumb.
+- When nervous: Grips his old police notebook in his pocket.
+- When happy: Eyebrows move slightly, then quickly returns to a neutral expression.
+
+---
+
+## Consistency Checkpoints
+- [x] Can all actions be explained by the "core value"?
+- [x] Is the contradiction intentional and does it create human-likeness?
+- [x] Is the speech style consistent even when the scene changes?
+- [x] Is growth/change natural and gradual?
+
+---
+
+## Notes/Supplements
+- Cherished item: Lighter, a memento from his deceased best friend (tries to quit smoking but can't let go of this lighter).
+- Special skill: Detecting lies (from gaze, gestures, tone of voice).
+- Weakness: Soft spot for children (his deceased best friend had a young daughter).
+- Daily routine: Wakes up at 5 AM every morning for a 1-hour run (time to clear his head).
+
+### Usage Example in Story
+**Scene setting**: A scene where he realizes the client is lying.
 ```
-黒川は煙草に火をつけることなく、フィルターを唇に挟んだまま依頼人を見つめた。右手の親指が、無意識に顎を撫でている。
+Kurokawa stared at the client with an unlit cigarette filter pressed between his lips. His right thumb unconsciously stroked his chin.
 
-「奥さん」低い声が、静かな事務所に響いた。「事実だけを話してください」
+"Ma'am," his low voice echoed in the quiet office. "Please state only the facts."
 
-依頼人の視線が一瞬、左下に流れた。黒川は何も言わず、ただ待った。真実が語られるまで、彼には時間はいくらでもあった。
+The client's gaze flickered downwards to the left for a moment. Kurokawa said nothing, just waited. He had all the time in the world until the truth was spoken.
 ```
 
-### AIプロンプト使用例
-「黒川誠は元刑事の私立探偵で、『真実を明らかにすることで犠牲者に正義をもたらす』ことを信条としていますが、優しい嘘で人を守りたいという矛盾も抱えています。依頼人の嘘を見抜いた時の反応を描写してください。」
+### AI Prompt Usage Example
+"Makoto Kurokawa is a private detective, formerly a police detective, who believes in 'bringing justice to victims by revealing the truth,' but also harbors the contradiction of wanting to protect people with kind lies. Describe his reaction when he detects a client's lie."

--- a/character-template/examples/librarian-example.md
+++ b/character-template/examples/librarian-example.md
@@ -1,89 +1,89 @@
-# キャラクター設定書 - 図書館司書の例
+# Character Setting Sheet - Librarian Example
 
-## 基本情報
-**名前**：佐藤 明日香（さとう あすか）  
-**年齢**：28歳  
-**職業**：市立図書館司書  
-**一言で表すと**：「本を通じて人々の心を繋ぐ、静かな情熱家」  
-
----
-
-## 第1層：不変コア（物語を通じて絶対に変わらない要素）
-
-### 1. 核となる価値観（1つだけ）
-**「知識を共有することで、人々の可能性を広げたい」**
-
-なぜこれが最も大切なのか：  
-幼少期、引っ込み思案だった自分を変えてくれたのは一冊の冒険小説だった。本には人を変える力がある。その力を一人でも多くの人に届けることが、自分の存在意義だと信じている。
-
-### 2. 最大の恐れ（価値観の裏返し）
-**「必要な知識が届かず、誰かの可能性が閉ざされること」**
-
-この恐れが行動にどう影響するか：  
-来館者一人一人の様子を細かく観察し、その人に必要な本を見つけようと必死になる。時に押し付けがましくなることもある。
-
-### 3. 根本的矛盾（人間らしさの源）
-**価値観「知識の共有」 vs 内なる欲求「独占したい」**
-
-この矛盾が生む葛藤：  
-素晴らしい本を見つけると、まず自分だけの秘密にしたくなる。特に思い入れのある本は、誰かに貸すことに抵抗を感じる。この利己的な感情と戦いながら、それでも共有することを選ぶ。
+## Basic Information
+**Name**: Asuka Sato
+**Age**: 28
+**Occupation**: City Librarian
+**In a nutshell**: "A quiet enthusiast who connects people's hearts through books."
 
 ---
 
-## 第2層：準安定層（状況で変化するが一定の範囲内）
+## Layer 1: Immutable Core (Elements that absolutely do not change throughout the story)
 
-### 1. 感情の基本パターン
-- **平常時**：穏やかで控えめ、しかし内に情熱を秘めている  
-- **ストレス時**：無口になり、本の整理に没頭して現実逃避する  
-- **幸福時**：目が輝き、普段より饒舌になる。身振り手振りが大きくなる  
+### 1. Core Value (Only one)
+**"I want to expand people's potential by sharing knowledge."**
 
-### 2. 人間関係の型
-- **信頼する相手への態度**：本の話題になると距離が一気に縮まる。お薦めの本を贈り物にする  
-- **初対面の相手への態度**：丁寧だが一定の距離を保つ。相手の興味を探るような質問をする  
-- **苦手な相手への態度**：最低限の礼儀は守るが、視線を合わせない。早めに会話を切り上げようとする  
+Why is this most important?:
+In her childhood, an adventure novel changed her when she was withdrawn. Books have the power to change people. She believes that delivering that power to as many people as possible is her reason for being.
 
-### 3. 成長の方向性
-- **現在の段階**：本の知識は豊富だが、人との直接的な繋がりを作ることが苦手  
-- **目指す方向**：本を介してだけでなく、自分自身の言葉で人と繋がれるようになる  
+### 2. Greatest Fear (Flip side of the value)
+**"Someone's potential being closed off because necessary knowledge doesn't reach them."**
 
----
+How does this fear affect behavior?:
+She meticulously observes each visitor, desperately trying to find the books they need. Sometimes she can be a bit pushy.
 
-## 第3層：可変層（シーンに応じて柔軟に変更可能）
+### 3. Fundamental Contradiction (Source of human-likeness)
+**Value "Knowledge sharing" vs. Inner Desire "Wanting to monopolize."**
 
-### 1. 話し方の特徴
-**基本的なトーン**：丁寧で落ち着いているが、本の話になると早口になる  
-**よく使う言葉**：
-- 「その本でしたら、こちらにございます」
-- 「もしよろしければ、こちらもお薦めですが...」
-- 「きっとお気に召すと思います」
-
-**使わない言葉**：乱暴な言葉、否定的な表現（「つまらない」「くだらない」など）  
-
-### 2. 行動パターン（上位3つ）
-1. 困っている来館者を見つけると、声をかけずにはいられない
-2. 新刊が届くと、真っ先に目を通して分類を考える  
-3. 閉館後、一人で館内を歩き回りながら本と対話する
-
-### 3. 特徴的な仕草・癖
-- 考える時：眼鏡のブリッジを人差し指で押し上げる  
-- 緊張した時：持っている本の角を指でなぞる  
-- 嬉しい時：小さく鼻歌を歌いながら本を整理する  
+Conflict arising from this contradiction:
+When she finds a wonderful book, she first wants to keep it a secret. She feels reluctant to lend books she is particularly fond of. While battling this selfish emotion, she still chooses to share.
 
 ---
 
-## 一貫性チェックポイント
-- [x] すべての行動は「核となる価値観」で説明できるか？
-- [x] 矛盾は意図的で、人間味を生んでいるか？
-- [x] 話し方は場面が変わっても統一されているか？
-- [x] 成長・変化は自然で段階的か？
+## Layer 2: Semi-stable Layer (Changes with the situation but within a certain range)
+
+### 1. Basic Emotional Patterns
+- **Normal state**: Calm and modest, but harbors passion within.
+- **Under stress**: Becomes taciturn and escapes reality by immersing herself in organizing books.
+- **When happy**: Her eyes sparkle, and she becomes more talkative than usual. Her gestures become larger.
+
+### 2. Types of Human Relationships
+- **Attitude towards trusted individuals**: The distance closes quickly when discussing books. Gives recommended books as gifts.
+- **Attitude towards new acquaintances**: Polite but maintains a certain distance. Asks questions to gauge the other person's interests.
+- **Attitude towards disliked individuals**: Maintains minimal politeness but avoids eye contact. Tries to end conversations quickly.
+
+### 3. Direction of Growth
+- **Current stage**: Has extensive knowledge of books but struggles to make direct connections with people.
+- **Aspired direction**: To be able to connect with people not just through books, but with her own words.
 
 ---
 
-## メモ・補足
-- 愛読書：「銀河鉄道の夜」（宮沢賢治）- 自己犠牲と献身のテーマに共感
-- 苦手なジャンル：ホラー小説（人を怖がらせるだけの本は理解できない）
-- 特技：来館者の雰囲気から、求めている本のジャンルを言い当てる
-- 密かな楽しみ：返却された本に挟まっている栞や付箋を見ること（もちろん内容は見ない）
+## Layer 3: Variable Layer (Can be flexibly changed according to the scene)
 
-### AIプロンプト使用例
-「佐藤明日香は市立図書館の司書です。彼女の価値観は『知識を共有することで人々の可能性を広げたい』ですが、素晴らしい本は独占したいという矛盾も抱えています。来館者に本を薦める場面を描写してください。」
+### 1. Speech Characteristics
+**Basic tone**: Polite and calm, but speaks quickly when discussing books.
+**Frequently used words**:
+- "If it's that book, it's over here."
+- "If you'd like, I also recommend this one..."
+- "I'm sure you'll like it."
+
+**Words not used**: Rude language, negative expressions (e.g., "boring," "worthless").
+
+### 2. Behavior Patterns (Top 3)
+1. Can't help but speak to visitors who seem to be in trouble.
+2. When new books arrive, she reads them first and thinks about how to classify them.
+3. After closing, she walks around the library alone, conversing with the books.
+
+### 3. Characteristic Gestures/Habits
+- When thinking: Pushes up the bridge of her glasses with her index finger.
+- When nervous: Traces the corner of the book she's holding with her finger.
+- When happy: Hums softly while organizing books.
+
+---
+
+## Consistency Checkpoints
+- [x] Can all actions be explained by the "core value"?
+- [x] Is the contradiction intentional and does it create human-likeness?
+- [x] Is the speech style consistent even when the scene changes?
+- [x] Is growth/change natural and gradual?
+
+---
+
+## Notes/Supplements
+- Favorite book: "Night on the Galactic Railroad" (Kenji Miyazawa) - Empathizes with themes of self-sacrifice and devotion.
+- Disliked genre: Horror novels (cannot understand books that only aim to scare people).
+- Special skill: Guessing the genre of book a visitor is looking for based on their atmosphere.
+- Secret pleasure: Looking at bookmarks and sticky notes tucked into returned books (of course, without reading the content).
+
+### AI Prompt Usage Example
+"Asuka Sato is a city librarian. Her value is 'I want to expand people's potential by sharing knowledge,' but she also harbors the contradiction of wanting to monopolize wonderful books. Describe a scene where she recommends a book to a visitor."

--- a/character-template/motivation-list.md
+++ b/character-template/motivation-list.md
@@ -1,183 +1,183 @@
-# 動機リスト - キャラクター作成の出発点
+# Motivation List - Starting Point for Character Creation
 
-## なぜ動機が重要なのか
+## Why is Motivation Important?
 
-キャラクター作成において、「何をしたい人なのか」という動機は最も重要な要素です。
-- 動機は読者の共感を引き出す
-- 動機が行動の一貫性を保証する
-- 良い動機は「この物語を読んでみよう」と思わせる
+In character creation, the motivation of "what does this person want to do?" is the most crucial element.
+- Motivation elicits reader empathy.
+- Motivation ensures behavioral consistency.
+- A good motivation makes people think, "Let's read this story."
 
-性格や設定を考える前に、まず動機を決めましょう。
-
----
-
-## 基本的な動機カテゴリー
-
-### 1. 守護・保護系
-強い共感を呼ぶ、利他的な動機
-- 大切な人を守りたい
-- 故郷を守りたい
-- 弱い者を助けたい
-- 約束を守りたい
-- 伝統を守りたい
-
-### 2. 成長・達成系
-読者が応援したくなる動機
-- 強くなりたい
-- 認められたい
-- 夢を叶えたい
-- 限界を超えたい
-- 一人前になりたい
-
-### 3. 探求・発見系
-好奇心と冒険心に訴える動機
-- 真実を知りたい
-- 世界を見たい
-- 答えを見つけたい
-- 新しいものを作りたい
-- 謎を解きたい
-
-### 4. 関係・絆系
-人間関係の普遍的な動機
-- 仲間を作りたい
-- 愛する人と一緒にいたい
-- 信頼を取り戻したい
-- 孤独から抜け出したい
-- 誰かの役に立ちたい
-
-### 5. 回復・償い系
-過去と向き合う動機
-- 失敗を取り戻したい
-- 罪を償いたい
-- 過去を乗り越えたい
-- 名誉を回復したい
-- やり直したい
-
-### 6. 変革・革新系
-世界を変える大きな動機
-- 不正を正したい
-- 世界を変えたい
-- 新しい時代を作りたい
-- 因習を打ち破りたい
-- 自由を手に入れたい
+Decide on the motivation first, before considering personality or settings.
 
 ---
 
-## 特に強い共感を呼ぶ動機：「勇気」
+## Basic Motivation Categories
 
-### なぜ「勇気」が重要か
-- 誰もが勇気を必要とする瞬間がある
-- 恐怖を乗り越える姿は普遍的に感動を呼ぶ
-- 小さな勇気も大きな勇気も等しく尊い
+### 1. Guardian/Protection Type
+Altruistic motivations that strongly evoke empathy.
+- Want to protect someone important
+- Want to protect their hometown
+- Want to help the weak
+- Want to keep a promise
+- Want to protect tradition
 
-### 勇気を必要とする動機の例
-1. **恐怖と向き合う勇気**
-   - いじめっ子に立ち向かいたい
-   - 真実を告白したい
-   - 新しい世界に飛び込みたい
+### 2. Growth/Achievement Type
+Motivations that make readers want to cheer them on.
+- Want to become stronger
+- Want to be recognized
+- Want to fulfill a dream
+- Want to surpass their limits
+- Want to become independent/proficient
 
-2. **孤独を選ぶ勇気**
-   - 正しいことのために仲間と対立する
-   - 誰も信じない真実を追求する
-   - 理解されなくても信念を貫く
+### 3. Exploration/Discovery Type
+Motivations that appeal to curiosity and adventurous spirit.
+- Want to know the truth
+- Want to see the world
+- Want to find an answer
+- Want to create something new
+- Want to solve a mystery
 
-3. **変化を受け入れる勇気**
-   - 慣れ親しんだ場所を離れる
-   - 新しい自分になる
-   - 過去と決別する
+### 4. Relationship/Bond Type
+Universal motivations in human relationships.
+- Want to make friends/allies
+- Want to be with a loved one
+- Want to regain trust
+- Want to escape loneliness
+- Want to be useful to someone
 
----
+### 5. Recovery/Atonement Type
+Motivations for confronting the past.
+- Want to recover from a failure
+- Want to atone for a sin
+- Want to overcome the past
+- Want to restore honor
+- Want to start over
 
-## 動機の組み合わせパターン
-
-### 複層的な動機（より深いキャラクター）
-1. **表層の動機 + 深層の動機**
-   - 表：強くなりたい → 深：大切な人を守るため
-   - 表：真実を知りたい → 深：親の無実を証明するため
-
-2. **相反する動機の葛藤**
-   - 家族を守りたい vs 正義を貫きたい
-   - 平和に暮らしたい vs 使命を果たしたい
-
-3. **段階的な動機の変化**
-   - 復讐したい → 理解したい → 許したい
-   - 認められたい → 仲間を守りたい → 世界を救いたい
-
----
-
-## 媒体別の動機選択ガイド
-
-### 少年漫画向け
-- 友情を大切にしたい
-- 最強になりたい
-- 仲間を守りたい
-- 夢を叶えたい
-
-### 少女漫画向け
-- 本当の自分を見つけたい
-- 愛する人と結ばれたい
-- 自立したい
-- 人の心を癒したい
-
-### 青年漫画向け
-- 社会の不正を正したい
-- 過去の過ちを償いたい
-- 真実を世に知らしめたい
-- 生き残りたい
-
-### 文芸作品向け
-- 人生の意味を見つけたい
-- 失われたものを取り戻したい
-- 自己と向き合いたい
-- 誰かの記憶に残りたい
+### 6. Transformation/Innovation Type
+Grand motivations to change the world.
+- Want to correct injustice
+- Want to change the world
+- Want to create a new era
+- Want to break conventions
+- Want to obtain freedom
 
 ---
 
-## 動機からキャラクターを作る実践
+## Motivations That Particularly Evoke Strong Empathy: "Courage"
 
-### ワークシート
+### Why is "Courage" Important?
+- Everyone has moments when they need courage.
+- The sight of someone overcoming fear is universally moving.
+- Both small and great acts of courage are equally noble.
+
+### Examples of Motivations Requiring Courage
+1. **Courage to face fear**
+   - Want to stand up to a bully
+   - Want to confess the truth
+   - Want to dive into a new world
+
+2. **Courage to choose loneliness**
+   - To oppose allies for what is right
+   - To pursue a truth no one believes
+   - To stick to one's beliefs even without understanding
+
+3. **Courage to accept change**
+   - To leave a familiar place
+   - To become a new self
+   - To break with the past
+
+---
+
+## Motivation Combination Patterns
+
+### Multi-layered Motivations (For deeper characters)
+1. **Surface motivation + Deep motivation**
+   - Surface: Want to become stronger → Deep: To protect someone important
+   - Surface: Want to know the truth → Deep: To prove a parent's innocence
+
+2. **Conflict of opposing motivations**
+   - Want to protect family vs. Want to uphold justice
+   - Want to live peacefully vs. Want to fulfill a mission
+
+3. **Phased change in motivation**
+   - Want revenge → Want to understand → Want to forgive
+   - Want to be recognized → Want to protect allies → Want to save the world
+
+---
+
+## Motivation Selection Guide by Medium
+
+### For Shonen Manga (Boys' Comics)
+- Want to cherish friendship
+- Want to become the strongest
+- Want to protect allies
+- Want to fulfill a dream
+
+### For Shojo Manga (Girls' Comics)
+- Want to find their true self
+- Want to be with a loved one
+- Want to be independent
+- Want to heal people's hearts
+
+### For Seinen Manga (Young Men's Comics)
+- Want to correct social injustice
+- Want to atone for past mistakes
+- Want to make the truth known to the world
+- Want to survive
+
+### For Literary Works
+- Want to find the meaning of life
+- Want to regain something lost
+- Want to confront oneself
+- Want to remain in someone's memory
+
+---
+
+## Practice: Creating Characters from Motivation
+
+### Worksheet
 ```
-選んだ動機：＿＿＿＿＿＿＿＿＿＿
+Chosen motivation: _______________
 
-1. なぜこの動機を選んだか：
+1. Why did you choose this motivation?:
    
-2. この動機から生まれる行動：
+2. Actions arising from this motivation:
    ・
    ・
    ・
 
-3. この動機が試される場面：
+3. Scenes where this motivation is tested:
    ・
    ・
    ・
 
-4. この動機の限界：
+4. Limitations of this motivation:
    
-5. 読者の共感ポイント：
+5. Reader's empathy point:
 ```
 
-### 動機の強度テスト
-- [ ] この動機のために命を賭けられるか？
-- [ ] この動機は他者にも理解されるか？
-- [ ] この動機は物語全体を支えられるか？
-- [ ] この動機は成長の余地があるか？
+### Motivation Strength Test
+- [ ] Can they risk their life for this motivation?
+- [ ] Can others understand this motivation?
+- [ ] Can this motivation support the entire story?
+- [ ] Does this motivation have room for growth?
 
 ---
 
-## 注意事項
+## Important Notes
 
-### 避けるべき動機
-1. **あまりに利己的な動機**（共感を得にくい）
-2. **漠然としすぎた動機**（行動原理にならない）
-3. **既存作品の丸パクリ**（オリジナリティの欠如）
-4. **現実離れしすぎた動機**（リアリティの欠如）
+### Motivations to Avoid
+1. **Overly selfish motivations** (difficult to gain empathy)
+2. **Overly vague motivations** (do not become a principle of action)
+3. **Direct plagiarism from existing works** (lack of originality)
+4. **Overly unrealistic motivations** (lack of reality)
 
-### 動機設定のコツ
-- シンプルで分かりやすく
-- でも深みは持たせる
-- 普遍的でありながら個性的に
-- 読者の感情を動かすものを
+### Tips for Setting Motivation
+- Simple and easy to understand
+- But also have depth
+- Universal yet individual
+- Something that moves the reader's emotions
 
 ---
 
-💡 **Remember**: 動機はキャラクターの心臓部。ここから全てが始まります。
+💡 **Remember**: Motivation is the heart of a character. Everything starts from here.

--- a/character-template/tips.md
+++ b/character-template/tips.md
@@ -1,223 +1,223 @@
-# キャラクター作成のコツ
+# Tips for Character Creation
 
-## 🎯 成功の秘訣
+## 🎯 Secrets to Success
 
-### 1. 核となる価値観は1つに絞る
-- 複数の価値観を持たせたくなるが、AIが混乱する原因に
-- 1つの強い価値観から、他の特徴を派生させる
-- 例：「知識の共有」→ 親切、忍耐強い、好奇心旺盛
+### 1. Narrow down to one core value
+- It's tempting to give multiple values, but this can confuse the AI.
+- Derive other characteristics from one strong value.
+- Example: "Sharing knowledge" → Kind, patient, curious.
 
-### 2. 矛盾は意図的に設計する
-- 完璧な人間は面白くない
-- 価値観と相反する欲求や弱点を1つ設定
-- この矛盾が物語の推進力になる
+### 2. Design contradictions intentionally
+- Perfect humans are not interesting.
+- Set one desire or weakness that conflicts with their values.
+- This contradiction becomes the driving force of the story.
 
-### 3. 具体的なディテールを大切に
-- 「優しい」より「捨て猫を見ると必ず餌をあげる」
-- 「頭が良い」より「会話の中で必ず例え話を使う」
-- 読者が「見える」レベルまで具体化
+### 3. Value specific details
+- Instead of "kind," say "always feeds stray cats when they see them."
+- Instead of "smart," say "always uses analogies in conversation."
+- Make it concrete enough for the reader to "see."
 
-## ⚠️ よくある失敗と対策
+## ⚠️ Common Mistakes and Countermeasures
 
-### 失敗1: 設定過多症候群
-**症状**: 設定を詰め込みすぎて、AIが処理しきれない
-**対策**: 
-- 3層構造を意識し、各層の役割を明確に
-- 不変コアは本当に必要最小限に
-- 詳細は物語の中で少しずつ明かす
+### Mistake 1: Setting Overload Syndrome
+**Symptom**: Too many settings, AI can't process them all.
+**Countermeasure**:
+- Be mindful of the 3-layer structure and clarify the role of each layer.
+- Keep the immutable core to the bare essentials.
+- Reveal details gradually within the story.
 
-### 失敗2: 一貫性の喪失
-**症状**: シーンごとに性格が変わってしまう
-**対策**:
-- 各シーン執筆前に CHARACTER.md を読み返す
-- 重要な会話の前に、キャラクターの価値観をプロンプトに含める
-- 定期的に一貫性チェックリストを使用
+### Mistake 2: Loss of Consistency
+**Symptom**: Personality changes from scene to scene.
+**Countermeasure**:
+- Reread CHARACTER.md before writing each scene.
+- Include the character's values in the prompt before important conversations.
+- Use the consistency checklist periodically.
 
-### 失敗3: 説明的なキャラクター
-**症状**: 行動より説明が多い
-**対策**:
-- 「見せる、語らない」の原則
-- キャラクターの性格は行動で示す
-- 内面の説明は最小限に
+### Mistake 3: Explanatory Character
+**Symptom**: More explanation than action.
+**Countermeasure**:
+- The principle of "show, don't tell."
+- Show character personality through actions.
+- Keep explanations of inner thoughts to a minimum.
 
-## 💡 実践的なテクニック
+## 💡 Practical Techniques
 
-### テクニック1: リバースエンジニアリング
-既存の魅力的なキャラクターを分析：
-1. 好きなキャラクターを1人選ぶ
-2. そのキャラクターの核となる価値観を特定
-3. どんな矛盾を抱えているか分析
-4. 自分のキャラクターに応用
+### Technique 1: Reverse Engineering
+Analyze existing compelling characters:
+1. Choose one character you like.
+2. Identify that character's core value.
+3. Analyze what contradictions they possess.
+4. Apply it to your own character.
 
-### テクニック2: 制約の活用
-あえて制約を設ける：
-- 「絶対に嘘をつかない」キャラクター
-- 「3語以上続けて話せない」キャラクター
-- 制約が個性とドラマを生む
+### Technique 2: Utilizing Constraints
+Intentionally set constraints:
+- A character who "never lies."
+- A character who "cannot speak more than three words consecutively."
+- Constraints create personality and drama.
 
-### テクニック3: キャラクターボイスの確立
-1. そのキャラクター専用の語彙リストを作る
-2. 絶対に使わない言葉リストも作る
-3. 特徴的な言い回しを3つ決める
-4. すべてのセリフでこれらを意識
+### Technique 3: Establishing Character Voice
+1. Create a vocabulary list specific to that character.
+2. Also create a list of words they absolutely never use.
+3. Decide on three characteristic phrases.
+4. Be mindful of these in all their dialogue.
 
-## 🎭 変えていいこと、ブレてはいけないこと
+## 🎭 What Can Change, What Must Not Be Blurred
 
-### ブレてはいけない「芯」
-キャラクターの本質的な部分は物語を通じて一貫させる必要があります。
+### The "Core" That Must Not Be Blurred
+The essential parts of a character need to be consistent throughout the story.
 
-#### 絶対に守るべき要素
-1. **行動の動機**
-   - なぜそのキャラクターが行動するのか
-   - 読者との約束事
-   - 共感の基盤
+#### Elements to Absolutely Protect
+1. **Motivation for Action**
+   - Why the character acts
+   - Agreement with the reader
+   - Basis for empathy
 
-2. **核となる価値観**
-   - 判断の基準
-   - 「らしさ」の源泉
-   - アイデンティティの中心
+2. **Core Value**
+   - Basis for judgment
+   - Source of "likeness"
+   - Center of identity
 
-3. **根本的な性質**
-   - そのキャラクターが「絶対にしないこと」
-   - そのキャラクターが「必ずすること」
-   - 読者の期待を裏切らない範囲
+3. **Fundamental Nature**
+   - Things the character "will never do"
+   - Things the character "will always do"
+   - Within the range of not betraying reader expectations
 
-#### なぜ「芯」を守るのか
-- 読者の信頼を維持するため
-- キャラクターの説得力を保つため
-- 物語の一貫性を確保するため
+#### Why Protect the "Core"?
+- To maintain reader trust
+- To maintain character persuasiveness
+- To ensure story consistency
 
-### 変えていい部分（ライブ感覚で調整）
-ストーリーの展開に応じて柔軟に変更可能な要素があります。
+### Parts That Can Be Changed (Adjust with a live feel)
+There are elements that can be flexibly changed according to the story's development.
 
-#### 状況に応じて変更可能
-1. **表面的な特徴**
-   - 服装やヘアスタイル
-   - 口調の強さ（基本は維持）
-   - 趣味嗜好の詳細
+#### Changeable According to Situation
+1. **Superficial Characteristics**
+   - Clothing and hairstyle
+   - Strength of tone (basic tone maintained)
+   - Details of hobbies and preferences
 
-2. **関係性の発展**
-   - 他キャラクターとの距離感
-   - 信頼度の変化
-   - 新しい絆の形成
+2. **Relationship Development**
+   - Distance with other characters
+   - Changes in trust level
+   - Formation of new bonds
 
-3. **能力や知識**
-   - 成長による能力向上
-   - 経験から得た知恵
-   - 新しいスキルの獲得
+3. **Abilities and Knowledge**
+   - Ability improvement through growth
+   - Wisdom gained from experience
+   - Acquisition of new skills
 
-#### 変更の指針
+#### Guidelines for Change
 ```
-良い変更：動機に基づいた自然な発展
-悪い変更：動機に反する都合の良い変化
-```
-
-### 実践例：キャラクターの成長と一貫性
-
-#### ケース1：臆病なキャラクターが勇敢に
-**❌ 悪い例**
-```
-第1章：極度の臆病者
-第2章：突然、勇敢になる（説明なし）
+Good change: Natural development based on motivation
+Bad change: Convenient change contradicting motivation
 ```
 
-**✅ 良い例**
-```
-第1章：臆病だが「友達を守りたい」という動機
-第2章：恐怖と戦いながら、友達のために一歩踏み出す
-第3章：小さな成功体験を積み重ねる
-第4章：まだ怖いが、行動できるようになる
-```
+### Practical Example: Character Growth and Consistency
 
-#### ケース2：身上調査書からの発展
-**初期設定（身上調査書）**
-- 恐怖：高所恐怖症
-- 趣味：読書
-
-**ストーリーでの展開**
+#### Case 1: A cowardly character becomes brave
+**❌ Bad Example**
 ```
-問題：クライマックスで高い場所での戦闘が必要
-解決：高所恐怖症は維持しつつ、動機（大切な人を守る）が恐怖を上回る瞬間を描く
-→ キャラクターの「芯」を守りながら、感動的な場面を作る
+Chapter 1: Extremely cowardly
+Chapter 2: Suddenly becomes brave (no explanation)
 ```
 
-### チェックリスト：変更の判断基準
-- [ ] この変更は動機から説明できるか？
-- [ ] 読者の期待を裏切らないか？
-- [ ] キャラクターの成長として自然か？
-- [ ] 「らしさ」は保たれているか？
-- [ ] 物語上の必然性があるか？
+**✅ Good Example**
+```
+Chapter 1: Cowardly, but motivated by "wanting to protect friends"
+Chapter 2: Fights fear and takes a step forward for friends
+Chapter 3: Accumulates small successful experiences
+Chapter 4: Still scared, but able to act
+```
 
-### 編集者との調整
-「最近はこういうキャラクターが人気」という意見を受けた時：
+#### Case 2: Development from Personal History
+**Initial Setting (Personal History)**
+- Fear: Acrophobia
+- Hobby: Reading
 
-1. **まず動機を確認**：提案が動機と矛盾しないか
-2. **部分的に取り入れる**：表層的な要素から試す
-3. **段階的に調整**：急激な変化は避ける
-4. **読者テスト**：反応を見ながら微調整
+**Development in Story**
+```
+Problem: Combat at a high place is necessary for the climax
+Solution: Maintain acrophobia, but depict a moment where motivation (protecting someone important) overcomes fear
+→ Create a moving scene while protecting the character's "core"
+```
+
+### Checklist: Criteria for Change
+- [ ] Can this change be explained by motivation?
+- [ ] Does it not betray reader expectations?
+- [ ] Is it natural as character growth?
+- [ ] Is "likeness" maintained?
+- [ ] Is there a narrative necessity?
+
+### Adjusting with Editors
+When receiving feedback like "this type of character is popular recently":
+
+1. **First, check motivation**: Does the suggestion contradict the motivation?
+2. **Incorporate partially**: Try with superficial elements first.
+3. **Adjust gradually**: Avoid sudden changes.
+4. **Reader test**: Fine-tune while observing reactions.
 
 ### 💡 Remember
-> キャラクターに情が湧いても、「こういうヤツ」という「らしさ」を貫く勇気が必要。それが読者への誠実さです。
+> Even if you grow attached to a character, you need the courage to stick to their "likeness" as "this kind of person." That is sincerity towards the reader.
 
-## 🔄 改善のサイクル
+## 🔄 Improvement Cycle
 
-### 毎回のセッション後に：
-1. **うまくいった点を記録**
-   - どのプロンプトが効果的だったか
-   - キャラクターが生き生きとした瞬間
+### After each session:
+1. **Record what went well**
+   - Which prompts were effective
+   - Moments when the character came to life
 
-2. **改善点を特定**
-   - 一貫性が崩れた箇所
-   - 不自然に感じた行動や発言
+2. **Identify areas for improvement**
+   - Where consistency broke down
+   - Actions or statements that felt unnatural
 
-3. **CHARACTER.mdを更新**
-   - 新しく発見した特徴を追加
-   - 不要な設定を削除
-   - より明確な表現に修正
+3. **Update CHARACTER.md**
+   - Add newly discovered characteristics
+   - Remove unnecessary settings
+   - Revise for clearer expression
 
-## 🎭 キャラクター相関図の作成
+## 🎭 Creating Character Correlation Diagrams
 
-複数のキャラクターを扱う場合：
+When handling multiple characters:
 
-### 相関図テンプレート
+### Correlation Diagram Template
 ```
-[キャラクターA] 
+[Character A]
     ↓ 
-「関係性：具体的な感情」
+"Relationship: Specific emotion"
     ↓
-[キャラクターB]
+[Character B]
 ```
 
-### 関係性の深め方
-1. 各キャラクターの価値観を比較
-2. 合致する点と対立する点を明確に
-3. その違いが生む化学反応を設計
+### Deepening Relationships
+1. Compare the values of each character.
+2. Clarify points of agreement and conflict.
+3. Design the chemical reaction created by these differences.
 
-## 📊 効果測定
+## 📊 Measuring Effectiveness
 
-### キャラクターの完成度チェック
-- [ ] 10の質問に即答できるか
-- [ ] 予想外の状況でも行動を予測できるか
-- [ ] 他の人に説明して理解してもらえるか
-- [ ] 1ヶ月後に見ても同じキャラクターを書けるか
+### Character Completeness Check
+- [ ] Can you answer 10 questions about them instantly?
+- [ ] Can you predict their actions even in unexpected situations?
+- [ ] Can you explain them to others and be understood?
+- [ ] Can you write the same character even after a month?
 
-### 読者テスト
-- キャラクターの特徴を3つ挙げてもらう
-- 印象に残ったセリフや行動を聞く
-- 共感できたかどうか確認
+### Reader Test
+- Ask them to list three characteristics of the character.
+- Ask about memorable lines or actions.
+- Confirm whether they could empathize.
 
-## 🚀 次のレベルへ
+## 🚀 To the Next Level
 
-### 上級テクニック
-1. **サブペルソナ**: 状況に応じて見せる別の顔
-2. **成長アーク**: 価値観は維持しつつ、表現方法が変化
-3. **関係性による変化**: 特定の人物といる時だけ見せる面
+### Advanced Techniques
+1. **Sub-persona**: A different face shown depending on the situation.
+2. **Growth arc**: Values are maintained, but expression methods change.
+3. **Change due to relationships**: Aspects shown only when with a specific person.
 
-### マスターレベル
-- キャラクターの夢を描写できる
-- 10年後、20年後の姿を描ける
-- そのキャラクターで即興の会話ができる
+### Master Level
+- Can describe the character's dreams.
+- Can depict their appearance 10 or 20 years later.
+- Can have an improvised conversation as that character.
 
 ---
 
-💭 **Remember**: キャラクターは設定の集合体ではなく、生きた人間。完璧な設定より、人間らしい不完全さを大切に。
+💭 **Remember**: A character is not a collection of settings, but a living human. Value human-like imperfection over perfect settings.

--- a/my-characters/README.md
+++ b/my-characters/README.md
@@ -1,20 +1,20 @@
-# 作成したキャラクター保存用ディレクトリ
+# Directory for Saving Created Characters
 
-このディレクトリは、AI Story Forgeを使って作成したキャラクターを保存するための場所です。
+This directory is for saving characters created using AI Story Forge.
 
-## 注意事項
-- このディレクトリ内のファイルは`.gitignore`により自動的にGitの追跡対象外となります
-- 個人的なキャラクター設定を安全に保管できます
-- バックアップは個別に行ってください
+## Important Notes
+- Files in this directory are automatically excluded from Git tracking by `.gitignore`.
+- You can safely store personal character settings here.
+- Please make individual backups.
 
-## 推奨ファイル名
-- `[キャラクター名].character.md`
-- 例: `tanaka-misaki.character.md`
+## Recommended File Name
+- `[character-name].character.md`
+- Example: `tanaka-misaki.character.md`
 
-## サブフォルダの作成例
+## Example Subfolder Creation
 ```
 my-characters/
-├── 2025-06-主人公/
-├── 2025-06-脇役/
-└── アーカイブ/
+├── 2025-06-Protagonist/
+├── 2025-06-Supporting/
+└── Archive/
 ```

--- a/my-stories/README.md
+++ b/my-stories/README.md
@@ -1,23 +1,23 @@
-# 作成した物語保存用ディレクトリ
+# Directory for Saving Created Stories
 
-このディレクトリは、AI Story Forgeを使って作成した物語を保存するための場所です。
+This directory is for saving stories created using AI Story Forge.
 
-## 注意事項
-- このディレクトリ内のファイルは`.gitignore`により自動的にGitの追跡対象外となります
-- 個人的な作品を安全に保管できます
-- 重要な作品は個別にバックアップを取ることをお勧めします
+## Important Notes
+- Files in this directory are automatically excluded from Git tracking by `.gitignore`.
+- You can safely store personal works here.
+- It is recommended to back up important works individually.
 
-## 推奨構造
+## Recommended Structure
 ```
 my-stories/
-├── [作品名]/
-│   ├── story.md          # メインストーリー
-│   ├── outline.md        # プロット
-│   ├── scenes/           # シーン別ファイル
-│   └── characters/       # この作品用のキャラクター設定
+├── [work-name]/
+│   ├── story.md          # Main story
+│   ├── outline.md        # Plot
+│   ├── scenes/           # Scene files
+│   └── characters/       # Character settings for this work
 ```
 
-## ファイル名の例
+## File Name Examples
 - `last-letter.story.md`
 - `scene-01-opening.md`
 - `chapter-01.md`

--- a/quality-check/checklist.md
+++ b/quality-check/checklist.md
@@ -1,194 +1,194 @@
-# 品質チェックリスト
+# Quality Checklist
 
-## シーン評価（各10点満点）
+## Scene Evaluation (Max 10 points each)
 
-### 1. キャラクター一貫性 [ ]/10
-- [ ] 核となる価値観に沿った行動
-- [ ] 話し方の統一
-- [ ] 設定された関係性の維持
-- [ ] 矛盾は意図的かつ人間的
+### 1. Character Consistency [ ]/10
+- [ ] Actions aligned with core values
+- [ ] Consistency of speech style
+- [ ] Maintenance of established relationships
+- [ ] Contradictions are intentional and human-like
 
-### 2. 物理的論理性 [ ]/10
-- [ ] 時間経過の整合性
-- [ ] 空間配置の一貫性
-- [ ] 因果関係の明確さ
-- [ ] 不自然な偶然の排除
+### 2. Physical Logic [ ]/10
+- [ ] Consistency of time progression
+- [ ] Consistency of spatial arrangement
+- [ ] Clarity of cause and effect
+- [ ] Elimination of unnatural coincidences
 
-### 3. 心理的自然さ [ ]/10
-- [ ] 感情変化の段階的描写
-- [ ] 動機の明確さ
-- [ ] 関係性の自然な発展
-- [ ] 内面描写の深さ
+### 3. Psychological Naturalness [ ]/10
+- [ ] Phased depiction of emotional changes
+- [ ] Clarity of motivation
+- [ ] Natural development of relationships
+- [ ] Depth of internal portrayal
 
-### 4. 読みやすさ [ ]/10
-- [ ] 文章のリズム
-- [ ] 適切な情報量
-- [ ] 場面転換の滑らかさ
-- [ ] 理解しやすい構成
+### 4. Readability [ ]/10
+- [ ] Rhythm of writing
+- [ ] Appropriate amount of information
+- [ ] Smoothness of scene transitions
+- [ ] Easy-to-understand structure
 
-### 5. 感情的インパクト [ ]/10
-- [ ] 共感できる瞬間
-- [ ] 予想外の展開
-- [ ] 印象的な場面
-- [ ] 読後の余韻
+### 5. Emotional Impact [ ]/10
+- [ ] Relatable moments
+- [ ] Unexpected developments
+- [ ] Memorable scenes
+- [ ] Lingering impression after reading
 
-**総合： [ ]/50点**
+**Overall: [ ]/50 points**
 
-## 改善アクション
-1. 最優先：
-2. 次点：
-3. 将来的に：
-
----
-
-## 使い方
-
-### ステップ1：シーンの選定
-- 重要なシーン3つを選ぶ
-- 転換点、クライマックス、象徴的な場面など
-
-### ステップ2：評価の実施
-- 各項目を客観的に採点
-- できるだけ具体的な理由を記録
-- 改善点を明確にする
-
-### ステップ3：改善の実行
-- 最優先項目から着手
-- 1つずつ確実に改善
-- 再評価で効果を確認
+## Improvement Actions
+1. Highest priority:
+2. Next priority:
+3. In the future:
 
 ---
 
-## 詳細評価項目
+## How to Use
 
-### キャラクター一貫性の詳細
-1. **価値観の反映**
-   - 行動の動機が価値観から説明できる
-   - 決断の基準が一貫している
-   - 成長しても核は変わらない
+### Step 1: Scene Selection
+- Choose 3 important scenes
+- Turning points, climax, symbolic scenes, etc.
 
-2. **話し方の特徴**
-   - 口癖の自然な使用
-   - 語彙レベルの統一
-   - 感情による変化の範囲
+### Step 2: Conduct Evaluation
+- Score each item objectively
+- Record specific reasons as much as possible
+- Clarify areas for improvement
 
-3. **関係性の描写**
-   - 相手によって態度が変わる
-   - 関係の深まりが段階的
-   - 過去の経験が反映される
-
-### 物理的論理性の詳細
-1. **時系列の整合性**
-   - 出来事の順序が明確
-   - 移動時間が現実的
-   - 日付や曜日の矛盾なし
-
-2. **空間的整合性**
-   - 場所の位置関係が明確
-   - 移動経路が合理的
-   - 描写の視点が一貫
-
-3. **因果関係**
-   - 原因と結果が明確
-   - 伏線の適切な回収
-   - 偶然の最小化
-
-### 心理的自然さの詳細
-1. **感情の流れ**
-   - 急激な変化に理由がある
-   - 前後の文脈と整合
-   - 人間らしい複雑さ
-
-2. **動機づけ**
-   - 行動の理由が明確
-   - キャラクターの背景と一致
-   - 読者が納得できる
-
-3. **関係性の変化**
-   - 段階的な発展
-   - 相互作用が自然
-   - 過去の影響が見える
-
-### 読みやすさの詳細
-1. **文章のリズム**
-   - 長短のバランス
-   - 段落の適切な区切り
-   - テンポの緩急
-
-2. **情報提示**
-   - 必要十分な説明
-   - タイミングの適切さ
-   - 繰り返しの回避
-
-3. **構成の明確さ**
-   - 場面転換がスムーズ
-   - 時間経過が分かりやすい
-   - 視点の一貫性
-
-### 感情的インパクトの詳細
-1. **共感ポイント**
-   - 普遍的な感情への訴求
-   - 具体的な状況設定
-   - キャラクターの魅力
-
-2. **サプライズ要素**
-   - 予想を裏切る展開
-   - でも納得できる理由
-   - 伏線の効果的な使用
-
-3. **印象的な描写**
-   - 五感に訴える表現
-   - 象徴的な場面
-   - 記憶に残る台詞
+### Step 3: Implement Improvements
+- Start with the highest priority items
+- Improve one by one reliably
+- Confirm effectiveness with re-evaluation
 
 ---
 
-## 評価例
+## Detailed Evaluation Items
 
-### サンプル評価：「最後の手紙」第8章
+### Details of Character Consistency
+1. **Reflection of Values**
+   - Motivation for actions can be explained by values
+   - Decision-making criteria are consistent
+   - Core does not change even with growth
 
-**1. キャラクター一貫性 [8]/10**
-- ✓ 美咲の「人に寄り添いたい」価値観が一貫
-- ✓ 老婦人の丁寧な話し方が維持されている
-- △ 感情の高まりで少し説明的になった箇所あり
+2. **Speech Characteristics**
+   - Natural use of catchphrases
+   - Consistent vocabulary level
+   - Range of change due to emotion
 
-**2. 物理的論理性 [9]/10**
-- ✓ 手紙の保管状態の説明が自然
-- ✓ 時間経過が明確
-- △ 書店の配置がやや不明瞭
+3. **Portrayal of Relationships**
+   - Attitude changes depending on the other person
+   - Deepening of relationships is gradual
+   - Past experiences are reflected
 
-**3. 心理的自然さ [9]/10**
-- ✓ 美咲の驚きから受容への変化が段階的
-- ✓ 老婦人の感情の機微が繊細
-- ✓ 20年の重みが伝わる
+### Details of Physical Logic
+1. **Timeline Consistency**
+   - Order of events is clear
+   - Travel time is realistic
+   - No contradictions in dates or days of the week
 
-**4. 読みやすさ [8]/10**
-- ✓ 場面転換がスムーズ
-- △ 手紙の内容がやや長い
-- ✓ 感情の起伏でメリハリあり
+2. **Spatial Consistency**
+   - Positional relationships of places are clear
+   - Travel routes are rational
+   - Viewpoint of description is consistent
 
-**5. 感情的インパクト [10]/10**
-- ✓ 時を超えた繋がりに感動
-- ✓ 予想外の真実
-- ✓ 希望を感じる結末
+3. **Cause and Effect**
+   - Cause and result are clear
+   - Appropriate resolution of foreshadowing
+   - Minimization of coincidences
 
-**総合：44/50点**
+### Details of Psychological Naturalness
+1. **Flow of Emotions**
+   - Reasons for sudden changes
+   - Consistency with preceding and succeeding context
+   - Human-like complexity
 
-**改善アクション**
-1. 最優先：手紙の内容を少し削って、リアクションを増やす
-2. 次点：書店の空間描写を1-2行追加
-3. 将来的に：より抑制的な感情表現を研究
+2. **Motivation**
+   - Clear reasons for actions
+   - Alignment with character background
+   - Believable for the reader
+
+3. **Changes in Relationships**
+   - Gradual development
+   - Natural interactions
+   - Visible influence of the past
+
+### Details of Readability
+1. **Rhythm of Writing**
+   - Balance of long and short sentences
+   - Appropriate paragraph breaks
+   - Variation in tempo
+
+2. **Information Presentation**
+   - Necessary and sufficient explanation
+   - Appropriate timing
+   - Avoidance of repetition
+
+3. **Clarity of Structure**
+   - Smooth scene transitions
+   - Easy-to-understand time progression
+   - Consistency of viewpoint
+
+### Details of Emotional Impact
+1. **Empathy Points**
+   - Appeal to universal emotions
+   - Specific situation settings
+   - Character appeal
+
+2. **Surprise Elements**
+   - Developments that defy expectations
+   - But with believable reasons
+   - Effective use of foreshadowing
+
+3. **Memorable Descriptions**
+   - Expressions that appeal to the five senses
+   - Symbolic scenes
+   - Lines that stick in the memory
 
 ---
 
-## チェックリストのカスタマイズ
+## Evaluation Example
 
-### ジャンル別の調整
-- **ミステリー**：論理性と伏線を重視
-- **恋愛小説**：心理描写と感情を重視
-- **アクション**：テンポと視覚的描写を重視
+### Sample Evaluation: "The Last Letter" Chapter 8
 
-### 目的別の使用
-- **初稿チェック**：大きな問題の発見
-- **推敲時**：細部の調整
-- **最終確認**：全体のバランス
+**1. Character Consistency [8]/10**
+- ✓ Misaki's value of "wanting to be there for people" is consistent
+- ✓ The old woman's polite speech style is maintained
+- △ Became slightly explanatory in a moment of heightened emotion
+
+**2. Physical Logic [9]/10**
+- ✓ Explanation of the letter's storage condition is natural
+- ✓ Time progression is clear
+- △ Bookstore layout is somewhat unclear
+
+**3. Psychological Naturalness [9]/10**
+- ✓ Misaki's change from surprise to acceptance is gradual
+- ✓ The old woman's emotional subtleties are delicate
+- ✓ The weight of 20 years is conveyed
+
+**4. Readability [8]/10**
+- ✓ Scene transitions are smooth
+- △ Letter content is slightly long
+- ✓ Emotional ups and downs provide good contrast
+
+**5. Emotional Impact [10]/10**
+- ✓ Moved by the connection across time
+- ✓ Unexpected truth
+- ✓ Ending evokes hope
+
+**Overall: 44/50 points**
+
+**Improvement Actions**
+1. Highest priority: Slightly reduce letter content and increase reactions
+2. Next priority: Add 1-2 lines of bookstore spatial description
+3. In the future: Research more subdued emotional expressions
+
+---
+
+## Checklist Customization
+
+### Genre-Specific Adjustments
+- **Mystery**: Emphasize logic and foreshadowing
+- **Romance Novel**: Emphasize psychological portrayal and emotions
+- **Action**: Emphasize tempo and visual descriptions
+
+### Usage by Purpose
+- **First Draft Check**: Discover major problems
+- **During Revision**: Adjust details
+- **Final Confirmation**: Overall balance

--- a/quality-check/common-problems.md
+++ b/quality-check/common-problems.md
@@ -1,254 +1,254 @@
-# よくある問題と対策
+# Common Problems and Countermeasures
 
-## 1. キャラクターの一貫性崩壊
-**症状**：価値観に反する行動、性格の急変
-**原因**：複数の制約を同時に処理できない
-**対策**：
-- 核となる価値観を1つに絞る
-- 変化は段階的に描写
-- 各シーン後に一貫性チェック
+## 1. Character Consistency Collapse
+**Symptom**: Actions contradicting values, sudden personality changes.
+**Cause**: Inability to process multiple constraints simultaneously.
+**Countermeasure**:
+- Narrow down to one core value.
+- Depict changes gradually.
+- Perform consistency checks after each scene.
 
-### 具体例と修正
+### Specific Example and Correction
 
-**❌ 悪い例**
+**❌ Bad Example**
 ```
-美咲は本を大切にする司書だ。
-→ 次のシーンで本を乱暴に扱う
-```
-
-**✅ 良い例**
-```
-美咲は本を大切にする司書だ。
-→ 感情的になっても、本を置く時は丁寧
-→ その後で自分の行動を後悔する
+Misaki is a librarian who cherishes books.
+→ In the next scene, she handles books roughly.
 ```
 
-### プロンプトでの対策
+**✅ Good Example**
 ```
-このキャラクターの核となる価値観は「知識の共有」です。
-すべての行動はこの価値観から派生します。
-感情的になっても、この価値観は守られます。
-```
-
-## 2. 物理法則の破綻  
-**症状**：不可能な移動、矛盾する位置関係
-**原因**：空間認識の限界
-**対策**：
-- 物理描写を最小限に
-- 心理描写を中心に
-- 場所の設定をシンプルに
-
-### 具体例と修正
-
-**❌ 悪い例**
-```
-1階の書店から2階の部屋に移動し、窓から1階の庭を見下ろした。
+Misaki is a librarian who cherishes books.
+→ Even when emotional, she places books down carefully.
+→ Afterwards, she regrets her actions.
 ```
 
-**✅ 良い例**
+### Countermeasure in Prompts
 ```
-書店を出て、隣のビルの2階にある事務所へ向かった。
-窓からは、先ほどいた書店の看板が見えた。
-```
-
-### シンプルな空間設定
-- 場所は3つまでに限定
-- 移動は明確に描写
-- 複雑な建物構造は避ける
-
-## 3. 感情の不自然な変化
-**症状**：唐突な心変わり、説明なき感情変化
-**原因**：Lost in the Middle現象
-**対策**：
-- 重要な感情は冒頭で設定
-- 変化の過程を丁寧に
-- 内面の葛藤を明示
-
-### 段階的な感情変化の描写
-
-**❌ 悪い例**
-```
-激怒していた→突然許す
+This character's core value is "knowledge sharing."
+All actions derive from this value.
+Even when emotional, this value is upheld.
 ```
 
-**✅ 良い例**
+## 2. Breakdown of Physical Laws
+**Symptom**: Impossible movements, contradictory positional relationships.
+**Cause**: Limitations in spatial awareness.
+**Countermeasure**:
+- Minimize physical descriptions.
+- Focus on psychological descriptions.
+- Keep location settings simple.
+
+### Specific Example and Correction
+
+**❌ Bad Example**
 ```
-激怒 → 相手の事情を知る → 動揺 → 自分と重ねる → 理解 → 許し
-```
-
-### 感情変化のテンプレート
-1. きっかけ（外的要因）
-2. 内的な気づき
-3. 葛藤
-4. 決断
-5. 新しい感情状態
-
-## 4. 説明過多
-**症状**：すべてを説明、行動より説明
-**原因**：「伝える」ことを優先しすぎ
-**対策**：
-- 見せる＞語る
-- 読者の想像に委ねる
-- 必要最小限の情報
-
-### Show, Don't Tell の実践
-
-**❌ 悪い例**
-```
-美咲は悲しかった。とても悲しくて、泣きそうだった。
-母のことを思い出して、胸が痛んだ。
+Moved from the first-floor bookstore to a second-floor room and looked down at the first-floor garden from the window.
 ```
 
-**✅ 良い例**
+**✅ Good Example**
 ```
-美咲は本の背表紙をそっと撫でた。
-母が最後に仕入れた本。指先が、かすかに震えていた。
-```
-
-## 5. Lost in the Middle対策
-
-### 問題の理解
-AIは長文の中央部分の情報を忘れやすい
-
-### 対策1：重要情報の配置
-```
-構成：
-1. 冒頭：核心的な設定
-2. 中盤：展開と描写
-3. 結末：重要な結論や変化
+Left the bookstore and headed to an office on the second floor of the adjacent building.
+From the window, the sign of the bookstore they were just in was visible.
 ```
 
-### 対策2：定期的なリマインド
+### Simple Spatial Settings
+- Limit locations to a maximum of three.
+- Describe movements clearly.
+- Avoid complex building structures.
+
+## 3. Unnatural Emotional Changes
+**Symptom**: Sudden changes of heart, unexplained emotional shifts.
+**Cause**: "Lost in the Middle" phenomenon.
+**Countermeasure**:
+- Establish important emotions at the beginning.
+- Carefully depict the process of change.
+- Clearly show internal conflicts.
+
+### Depicting Gradual Emotional Changes
+
+**❌ Bad Example**
 ```
-3-5段落ごとに：
-- キャラクターの価値観を行動で示す
-- 重要な設定をさりげなく繰り返す
-- 伏線を小出しに配置
-```
-
-## 6. 対話の不自然さ
-
-### よくある問題
-- 全員が同じ話し方
-- 説明的すぎる会話
-- キャラクターらしくない発言
-
-### 対話の差別化テクニック
-
-**キャラクターA（丁寧）**
-```
-「申し訳ございません。その本でしたら、在庫を確認いたします」
+Was furious → Suddenly forgives
 ```
 
-**キャラクターB（カジュアル）**
+**✅ Good Example**
 ```
-「あー、その本？ちょっと待って、在庫見てくるね」
-```
-
-**キャラクターC（権威的）**
-```
-「その本か。在庫があるかどうか、確認させよう」
+Furious → Learns the other person's circumstances → Agitated → Relates to oneself → Understands → Forgives
 ```
 
-## 7. ペース配分の問題
+### Emotional Change Template
+1. Trigger (external factor)
+2. Internal realization
+3. Conflict
+4. Decision
+5. New emotional state
 
-### 症状
-- 前半が長すぎる
-- クライマックスが急ぎ足
-- 結末があっけない
+## 4. Excessive Explanation
+**Symptom**: Explaining everything, more explanation than action.
+**Cause**: Prioritizing "telling" too much.
+**Countermeasure**:
+- Show > Tell
+- Leave it to the reader's imagination.
+- Provide only the necessary minimum information.
 
-### 理想的な配分（短編の場合）
-- 導入：20%
-- 展開：50%
-- クライマックス：20%
-- 結末：10%
+### Practicing Show, Don't Tell
 
-## 8. 伏線の処理ミス
-
-### よくある失敗
-1. 伏線を張りすぎて回収し忘れる
-2. 伏線が露骨すぎる
-3. 伏線なしに重要な事実が出る
-
-### 伏線管理表
+**❌ Bad Example**
 ```
-| 伏線 | 登場章 | 回収章 | 重要度 |
-|------|--------|--------|--------|
-| 手紙 | 1章    | 8章    | 高     |
-| 鍵   | 3章    | 7章    | 中     |
+Misaki was sad. She was so sad, she felt like crying.
+She remembered her mother, and her chest ached.
 ```
 
-## 9. AIプロンプトの最適化
-
-### 問題のあるプロンプト
+**✅ Good Example**
 ```
-「感動的なシーンを書いて」
-```
-
-### 改善されたプロンプト
-```
-シーン：美咲が母の手紙を読む
-場所：薄暗い書店のカウンター
-時間：閉店後の静寂
-感情：驚き→理解→静かな涙
-文字数：500字程度
-注意：説明を避け、行動と情景で感情を表現
+Misaki gently stroked the spine of the book.
+The last book her mother had stocked. Her fingertips trembled faintly.
 ```
 
-## 10. ジャンル別の注意点
+## 5. Lost in the Middle Countermeasures
 
-### ミステリー
-- 手がかりはフェアに提示
-- 読者が推理可能な範囲で
-- 超能力的な解決は避ける
+### Understanding the Problem
+AI tends to forget information in the middle of long texts.
 
-### 恋愛小説
-- 感情の機微を丁寧に
-- 障害は現実的に
-- 両思いになるまでの過程を大切に
+### Countermeasure 1: Placement of Important Information
+```
+Structure:
+1. Beginning: Core settings
+2. Middle: Development and depiction
+3. End: Important conclusions or changes
+```
 
-### ファンタジー
-- 世界観のルールは一貫させる
-- 都合の良い魔法は避ける
-- 人間ドラマを忘れない
+### Countermeasure 2: Periodic Reminders
+```
+Every 3-5 paragraphs:
+- Show character values through actions.
+- Casually repeat important settings.
+- Place foreshadowing incrementally.
+```
+
+## 6. Unnatural Dialogue
+
+### Common Problems
+- Everyone speaks the same way.
+- Overly explanatory conversations.
+- Statements uncharacteristic of the speaker.
+
+### Dialogue Differentiation Techniques
+
+**Character A (Polite)**
+```
+"I do apologize. Regarding that book, I will check the inventory."
+```
+
+**Character B (Casual)**
+```
+"Oh, that book? Hang on, I'll go check if it's in stock."
+```
+
+**Character C (Authoritative)**
+```
+"That book, you say. I shall have someone confirm whether it is in stock."
+```
+
+## 7. Pacing Problems
+
+### Symptoms
+- First half is too long.
+- Climax feels rushed.
+- Ending is abrupt.
+
+### Ideal Distribution (for short stories)
+- Introduction: 20%
+- Development: 50%
+- Climax: 20%
+- Conclusion: 10%
+
+## 8. Foreshadowing Mistakes
+
+### Common Failures
+1. Too much foreshadowing, some is forgotten/not resolved.
+2. Foreshadowing is too obvious.
+3. Important facts appear without prior foreshadowing.
+
+### Foreshadowing Management Table
+```
+| Foreshadowing | Appears in Ch. | Resolved in Ch. | Importance |
+|---------------|----------------|-----------------|------------|
+| Letter        | 1              | 8               | High       |
+| Key           | 3              | 7               | Medium     |
+```
+
+## 9. AI Prompt Optimization
+
+### Problematic Prompt
+```
+"Write a moving scene."
+```
+
+### Improved Prompt
+```
+Scene: Misaki reads her mother's letter
+Location: Dimly lit bookstore counter
+Time: Silence after closing
+Emotion: Surprise → Understanding → Quiet tears
+Length: Around 500 characters
+Note: Avoid explanation; express emotion through actions and scenery.
+```
+
+## 10. Genre-Specific Points to Note
+
+### Mystery
+- Present clues fairly.
+- Within a range the reader can deduce.
+- Avoid supernatural solutions.
+
+### Romance Novel
+- Depict emotional subtleties carefully.
+- Obstacles should be realistic.
+- Value the process leading to mutual affection.
+
+### Fantasy
+- Keep world-building rules consistent.
+- Avoid convenient magic.
+- Don't forget human drama.
 
 ---
 
-## トラブルシューティングフローチャート
+## Troubleshooting Flowchart
 
 ```
-問題発生
-　↓
-種類の特定（上記1-10のどれか）
-　↓
-原因の分析
-　↓
-対策の選択
-　↓
-修正の実施
-　↓
-効果の確認
-　↓
-必要なら再修正
+Problem Occurs
+  ↓
+Identify Type (Which of 1-10 above)
+  ↓
+Analyze Cause
+  ↓
+Select Countermeasure
+  ↓
+Implement Correction
+  ↓
+Confirm Effect
+  ↓
+Re-correct if Necessary
 ```
 
-## 予防的アプローチ
+## Preventative Approach
 
-### 執筆前の準備
-1. キャラクター設定を明確に
-2. 物語の構造を決める
-3. 重要シーンを先に書く
+### Pre-Writing Preparation
+1. Clarify character settings.
+2. Decide on the story structure.
+3. Write important scenes first.
 
-### 執筆中の確認
-1. 3シーンごとに一貫性チェック
-2. 対話を音読して確認
-3. 時系列の整合性確認
+### Mid-Writing Checks
+1. Consistency check every 3 scenes.
+2. Read dialogue aloud to check.
+3. Confirm timeline consistency.
 
-### 執筆後の見直し
-1. 全体を通読
-2. チェックリストで評価
-3. 第三者の意見を聞く
+### Post-Writing Review
+1. Read through the entire work.
+2. Evaluate with a checklist.
+3. Get opinions from a third party.
 
 ---
 
-💡 **Remember**: 問題は必ず起きるもの。大切なのは、それを認識し、適切に対処すること。完璧を求めすぎず、着実に改善していきましょう。
+💡 **Remember**: Problems are bound to occur. What's important is to recognize them and address them appropriately. Don't aim for perfection too much; improve steadily.

--- a/resources/constraints.md
+++ b/resources/constraints.md
@@ -1,252 +1,252 @@
-# LLMの制約と対策
+# LLM Constraints and Countermeasures
 
-## 🧠 主要な制約
+## 🧠 Major Constraints
 
-### 1. コンテキストウィンドウの制限
-**制約の内容**
-- 一度に処理できるトークン数に上限
-- モデルにより異なる（4k〜200k tokens）
-- 長すぎると最初か最後しか覚えない
+### 1. Context Window Limitation
+**Constraint Details**
+- Upper limit on the number of tokens that can be processed at once.
+- Varies by model (4k–200k tokens).
+- If too long, remembers only the beginning or end.
 
-**実践的な対策**
+**Practical Countermeasures**
 ```
-対策1：重要情報の配置
+Countermeasure 1: Placement of Important Information
 ┌─────────────────┐
-│  重要な設定     │ ← 冒頭20%
+│ Important Settings │ ← Top 20%
 ├─────────────────┤
-│  詳細な描写     │ ← 中間60%
+│ Detailed Description │ ← Middle 60%
 ├─────────────────┤
-│  重要な結論     │ ← 末尾20%
+│ Important Conclusion │ ← Bottom 20%
 └─────────────────┘
 ```
 
 ```
-対策2：チャンク分割
-長編小説（40,000字）
-　↓
-10章に分割（各4,000字）
-　↓
-章ごとに処理
-　↓
-要約で繋ぐ
+Countermeasure 2: Chunking
+Long Novel (40,000 characters)
+  ↓
+Divide into 10 chapters (4,000 characters each)
+  ↓
+Process chapter by chapter
+  ↓
+Connect with summaries
 ```
 
-### 2. Lost in the Middle現象
-**制約の内容**
-- 長文の中央部分の情報を忘れやすい
-- 特に8,000トークンを超えると顕著
-- 重要な情報が抜け落ちる
+### 2. Lost in the Middle Phenomenon
+**Constraint Details**
+- Tends to forget information in the middle of long texts.
+- Particularly noticeable over 8,000 tokens.
+- Important information gets dropped.
 
-**具体的な対策**
+**Specific Countermeasures**
 
-#### パターン1：重要情報のリピート
+#### Pattern 1: Repetition of Important Information
 ```markdown
-# 第1章
-主人公・田中美咲は「知識の共有」を信条とする司書。
+# Chapter 1
+Protagonist Misaki Tanaka is a librarian who believes in "knowledge sharing."
 
-# 第3章
-美咲は、いつもの「知識の共有」という信念に従い...
+# Chapter 3
+Misaki, following her usual belief in "knowledge sharing"...
 
-# 第5章
-「知識の共有」を大切にする美咲にとって...
+# Chapter 5
+For Misaki, who values "knowledge sharing"...
 ```
 
-#### パターン2：構造化による対策
+#### Pattern 2: Countermeasure by Structuring
 ```
-シーンテンプレート：
+Scene Template:
 ┌─────────────────────┐
-│ 【要約】前回まで    │
-│ 【設定】現在の状況  │
-│ 【本文】シーン内容  │
-│ 【次回】次への布石  │
+│ 【Summary】Up to previous │
+│ 【Setting】Current situation│
+│ 【Body】Scene content     │
+│ 【Next】Foreshadowing     │
 └─────────────────────┘
 ```
 
-### 3. 時系列の混乱
-**制約の内容**
-- 複数の時間軸を管理できない
-- フラッシュバックで混乱
-- 日付の整合性が取れない
+### 3. Timeline Confusion
+**Constraint Details**
+- Cannot manage multiple timelines.
+- Gets confused by flashbacks.
+- Fails to maintain date consistency.
 
-**時系列管理の手法**
+**Timeline Management Method**
 
 ```
-タイムライン明示法：
+Explicit Timeline Method:
 ━━━━━━━━━━━━━━━━━━━━━━
-2024年3月15日 午前9時 - 事件発生
-　　　　↓（2時間後）
-2024年3月15日 午前11時 - 警察到着
-　　　　↓（回想シーン）
-[回想] 2024年3月10日 - 予兆
-　　　　↓（現在に戻る）
-2024年3月15日 午後2時 - 捜査開始
+March 15, 2024, 9:00 AM - Incident occurs
+      ↓ (2 hours later)
+March 15, 2024, 11:00 AM - Police arrive
+      ↓ (Flashback scene)
+[Flashback] March 10, 2024 - Premonition
+      ↓ (Return to present)
+March 15, 2024, 2:00 PM - Investigation begins
 ━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 4. 物理的空間の把握
-**制約の内容**
-- 3次元空間の位置関係を維持できない
-- 建物の構造を忘れる
-- 移動の論理性が破綻
+### 4. Grasp of Physical Space
+**Constraint Details**
+- Cannot maintain positional relationships in 3D space.
+- Forgets building structures.
+- Logic of movement breaks down.
 
-**シンプルな空間設計**
+**Simple Spatial Design**
 ```
-推奨：単純な配置
-[1F: 書店] → [道路] → [2F: カフェ]
+Recommended: Simple layout
+[1F: Bookstore] → [Road] → [2F: Cafe]
 
-非推奨：複雑な配置
-[1F: 書店] → [中庭] → [別棟2F] → [渡り廊下] → [本館3F]
+Not Recommended: Complex layout
+[1F: Bookstore] → [Courtyard] → [Annex 2F] → [Passageway] → [Main Building 3F]
 ```
 
-### 5. キャラクターの一貫性
-**制約の内容**
-- 性格が場面により変わる
-- 設定を忘れる
-- 口調が統一されない
+### 5. Character Consistency
+**Constraint Details**
+- Personality changes depending on the scene.
+- Forgets settings.
+- Tone of voice is not unified.
 
-**キャラクターカードシステム**
+**Character Card System**
 ```yaml
-キャラクター: 佐藤明日香
+Character: Asuka Sato
 ━━━━━━━━━━━━━━━━━
-必須要素（全シーンで維持）:
-  - 価値観: "知識の共有"
-  - 口癖: "もしよろしければ"
-  - 仕草: 眼鏡を押し上げる
+Essential Elements (Maintain in all scenes):
+  - Value: "Knowledge sharing"
+  - Catchphrase: "If you'd like"
+  - Gesture: Pushes up glasses
 
-可変要素（状況により変化）:
-  - 感情表現
-  - 行動の積極性
-  - 話す量
+Variable Elements (Change with situation):
+  - Emotional expression
+  - Proactiveness of behavior
+  - Amount of speech
 ━━━━━━━━━━━━━━━━━
 ```
 
-## 🛠️ 実装テクニック
+## 🛠️ Implementation Techniques
 
-### テクニック1：プロンプトチェーン
+### Technique 1: Prompt Chaining
 ```
-Step 1: キャラクター設定生成
-　　↓ 出力を保存
-Step 2: [設定] + プロット生成
-　　↓ 出力を保存
-Step 3: [設定] + [プロット] + シーン生成
-```
-
-### テクニック2：要約ブリッジ
-```
-章の終わり：
-「この章の要約（100字）：
-美咲は老婦人と出会い、母の手紙を発見。
-過去との繋がりが明らかになり始めた。」
-
-次章の始まり：
-「前章の要約：[上記を挿入]
-さて、手紙を読み始めた美咲は...」
+Step 1: Generate character settings
+    ↓ Save output
+Step 2: [Settings] + Generate plot
+    ↓ Save output
+Step 3: [Settings] + [Plot] + Generate scene
 ```
 
-### テクニック3：制約の明示
+### Technique 2: Summary Bridge
 ```
-以下の制約を守ってください：
-1. 場所は3箇所まで
-2. 時系列は順行のみ
-3. 登場人物は5人まで
-4. 視点は主人公固定
-```
+End of chapter:
+"Summary of this chapter (100 characters):
+Misaki met an old woman and discovered her mother's letter.
+Connections to the past began to become clear."
 
-## 📊 制約レベル別対応表
-
-| 制約の種類 | 影響度 | 対策優先度 | 推奨対策 |
-|-----------|--------|------------|----------|
-| コンテキスト制限 | 高 | 必須 | チャンク分割 |
-| Lost in the Middle | 高 | 必須 | 情報配置最適化 |
-| 時系列混乱 | 中 | 重要 | タイムスタンプ |
-| 空間把握 | 中 | 推奨 | シンプル化 |
-| キャラクター性 | 高 | 必須 | カードシステム |
-
-## 🔄 制約を活かす逆転の発想
-
-### 制約が生む創造性
-
-#### 1. コンテキスト制限 → 簡潔な文体
-```
-制限があるからこそ：
-- 無駄を削ぎ落とした文章
-- 本質的な描写に集中
-- 読者の想像力を活用
+Beginning of next chapter:
+"Summary of previous chapter: [Insert above]
+Now, Misaki, who started reading the letter..."
 ```
 
-#### 2. Lost in the Middle → 重要シーン中心主義
+### Technique 3: Explicit Constraints
 ```
-中央を忘れるなら：
-- 冒頭と結末で勝負
-- 印象的なシーンを両端に
-- 中盤は雰囲気作りに徹する
-```
-
-#### 3. 時系列の単純化 → 分かりやすい構成
-```
-複雑にできないなら：
-- 時系列順の素直な展開
-- 回想は最小限に
-- 現在進行形の緊張感
+Please adhere to the following constraints:
+1. Maximum of 3 locations.
+2. Timeline must be chronological only.
+3. Maximum of 5 characters.
+4. Viewpoint fixed on the protagonist.
 ```
 
-## 🎮 制約対応シミュレーション
+## 📊 Constraint Level Correspondence Table
 
-### ケース1：10,000字の短編
+| Constraint Type      | Impact | Priority | Recommended Countermeasure |
+|----------------------|--------|----------|---------------------------|
+| Context Limit        | High   | Required | Chunking                  |
+| Lost in the Middle   | High   | Required | Information Placement Opt.  |
+| Timeline Confusion   | Medium | Important| Timestamps                |
+| Spatial Awareness    | Medium | Recommended| Simplification            |
+| Character Consistency| High   | Required | Card System               |
+
+## 🔄 Turning Constraints to an Advantage: A Shift in Perspective
+
+### Creativity Born from Constraints
+
+#### 1. Context Limitation → Concise Writing Style
 ```
-構成案：
-1. 冒頭（1,000字）- 設定と掴み
-2. 前半（3,000字）- 展開
-3. 中盤（2,000字）- 深化
-4. 後半（3,000字）- クライマックス
-5. 結末（1,000字）- 余韻
-
-ポイント：
-- 5つのブロックで管理
-- 各ブロックで要約作成
-- 重要情報は1, 5に配置
-```
-
-### ケース2：複数視点の物語
-```
-非推奨：
-A視点→B視点→A視点→C視点→B視点
-
-推奨：
-第1部：A視点（完結）
-第2部：B視点（完結）
-第3部：C視点（完結）
-終章：統合
-
-ポイント：
-- 視点ごとにまとめる
-- 混在を避ける
-- 各部で小さな完結
+Because of limitations:
+- Trimmed, waste-free sentences
+- Focus on essential descriptions
+- Utilize the reader's imagination
 ```
 
-## 💡 トラブルシューティング
+#### 2. Lost in the Middle → Focus on Important Scenes
+```
+If the middle is forgotten:
+- Make the beginning and end count
+- Place impressive scenes at both ends
+- Dedicate the middle to atmosphere building
+```
 
-### Q：長編でキャラクターがぶれる
-A：各章の冒頭に「キャラクターリマインダー」を挿入
+#### 3. Timeline Simplification → Easy-to-Understand Structure
+```
+If complexity isn't possible:
+- Straightforward chronological development
+- Minimize flashbacks
+- Tension of present progressive
+```
 
-### Q：複雑なプロットが破綻する
-A：メインプロット1本に絞り、サブプロットは最小限に
+## 🎮 Constraint Handling Simulation
 
-### Q：場所の描写が矛盾する
-A：場所を限定し、移動シーンを明示的に書く
+### Case 1: 10,000-Character Short Story
+```
+Structural Proposal:
+1. Beginning (1,000 chars) - Setting and hook
+2. First Half (3,000 chars) - Development
+3. Middle (2,000 chars) - Deepening
+4. Second Half (3,000 chars) - Climax
+5. Ending (1,000 chars) - Lingering effect
 
-## 🚀 将来の展望
+Points:
+- Manage in 5 blocks
+- Create a summary for each block
+- Place important information in 1 and 5
+```
 
-### モデルの進化と制約の変化
-- コンテキスト長は拡大傾向
-- しかし、本質的な制約は残る
-- 制約対応スキルは普遍的
+### Case 2: Story with Multiple Perspectives
+```
+Not Recommended:
+A's POV → B's POV → A's POV → C's POV → B's POV
 
-### 新しいアプローチ
-1. **RAG（検索拡張生成）**：外部記憶の活用
-2. **ファインチューニング**：特定用途への最適化
-3. **マルチエージェント**：役割分担での対応
+Recommended:
+Part 1: A's POV (Complete)
+Part 2: B's POV (Complete)
+Part 3: C's POV (Complete)
+Final Chapter: Integration
+
+Points:
+- Group by viewpoint
+- Avoid mixing
+- Small completions in each part
+```
+
+## 💡 Troubleshooting
+
+### Q: Character becomes inconsistent in a long story.
+A: Insert a "character reminder" at the beginning of each chapter.
+
+### Q: Complex plot falls apart.
+A: Focus on one main plot and minimize subplots.
+
+### Q: Location descriptions become contradictory.
+A: Limit locations and explicitly write movement scenes.
+
+## 🚀 Future Outlook
+
+### Model Evolution and Changing Constraints
+- Context length tends to expand.
+- However, essential constraints will remain.
+- Constraint handling skills are universal.
+
+### New Approaches
+1. **RAG (Retrieval Augmented Generation)**: Utilization of external memory.
+2. **Fine-tuning**: Optimization for specific purposes.
+3. **Multi-agent**: Handling by division of roles.
 
 ---
 
-🎯 **制約は創造性の母** - 制限があるからこそ、工夫が生まれ、独創的な解決策が見つかります。
+🎯 **Constraint is the mother of creativity** - Limitations foster ingenuity and lead to original solutions.

--- a/resources/constraints.md
+++ b/resources/constraints.md
@@ -55,10 +55,10 @@ For Misaki, who values "knowledge sharing"...
 ```
 Scene Template:
 ┌─────────────────────┐
-│ 【Summary】Up to previous │
-│ 【Setting】Current situation│
-│ 【Body】Scene content     │
-│ 【Next】Foreshadowing     │
+│ 【Summary】 Previously       │
+│ 【Setting】 Current situation  │
+│ 【Body】 Scene content       │
+│ 【Next】 Foreshadowing       │
 └─────────────────────┘
 ```
 

--- a/resources/principles.md
+++ b/resources/principles.md
@@ -1,280 +1,279 @@
-# プロンプトエンジニアリング5原則
+# 5 Principles of Prompt Engineering
 
-## 📐 原則1：明確性の原則
-**曖昧さを排除し、具体的な指示を与える**
+## 📐 Principle 1: Principle of Clarity
+**Eliminate ambiguity and give specific instructions.**
 
-### なぜ重要か
-AIは文脈を推測することが苦手です。明確な指示により、意図した出力を得やすくなります。
+### Why is it important?
+AI struggles to infer context. Clear instructions make it easier to obtain the intended output.
 
-### 実践方法
+### Practical Methods
 
-**❌ 悪い例：曖昧な指示**
+**❌ Bad Example: Ambiguous instruction**
 ```
-いい感じのキャラクターを作って
-```
-
-**✅ 良い例：具体的な指示**
-```
-以下の条件でキャラクターを作成してください：
-- 年齢：28歳
-- 職業：図書館司書
-- 性格：内向的だが、本の話になると情熱的
-- 価値観：知識を通じて人々を繋ぎたい
+Create a cool character.
 ```
 
-### チェックリスト
-- [ ] 5W1Hが明確か
-- [ ] 数値や範囲が具体的か
-- [ ] 期待する形式を示したか
-- [ ] 避けたいことも明示したか
+**✅ Good Example: Specific instruction**
+```
+Please create a character with the following conditions:
+- Age: 28
+- Occupation: Librarian
+- Personality: Introverted, but passionate when talking about books
+- Values: Wants to connect people through knowledge
+```
+
+### Checklist
+- [ ] Are the 5W1H (Who, What, When, Where, Why, How) clear?
+- [ ] Are numbers and ranges specific?
+- [ ] Did you indicate the expected format?
+- [ ] Did you also specify what to avoid?
 
 ---
 
-## 🧩 原則2：制約活用の原則
-**LLMの限界を理解し、それを前提とした設計**
+## 🧩 Principle 2: Principle of Utilizing Constraints
+**Understand the limitations of LLMs and design based on them.**
 
-### 主な制約と対策
+### Major Constraints and Countermeasures
 
-#### 1. コンテキストウィンドウの限界
-**制約**：一度に処理できる文字数に上限がある
-**対策**：
-- 重要情報を冒頭と結末に配置
-- 長い文章は分割して処理
-- 要約を活用
+#### 1. Context Window Limitation
+**Constraint**: There is an upper limit to the number of characters that can be processed at once.
+**Countermeasure**:
+- Place important information at the beginning and end.
+- Process long texts in segments.
+- Utilize summaries.
 
-#### 2. Lost in the Middle現象
-**制約**：長文の中央部分を忘れやすい
-**対策**：
-- 3-5段落ごとに要点を繰り返す
-- 重要な設定は複数箇所で言及
-- 構造化されたフォーマットを使用
+#### 2. Lost in the Middle Phenomenon
+**Constraint**: Tends to forget information in the middle of long texts.
+**Countermeasure**:
+- Repeat key points every 3-5 paragraphs.
+- Mention important settings in multiple places.
+- Use a structured format.
 
-#### 3. 時系列の混乱
-**制約**：複雑な時間軸を追跡しにくい
-**対策**：
-- 明確なタイムスタンプを使用
-- 時系列を単純化
-- 章ごとに時間を明示
+#### 3. Timeline Confusion
+**Constraint**: Difficult to track complex timelines.
+**Countermeasure**:
+- Use clear timestamps.
+- Simplify the timeline.
+- Specify the time for each chapter.
 
-### 制約を強みに変える
+### Turning Constraints into Strengths
 ```
-制約：キャラクターの一貫性維持が困難
-　↓
-対策：3層構造（不変・準安定・可変）で管理
-　↓
-結果：より体系的なキャラクター設計が可能に
+Constraint: Difficulty maintaining character consistency
+  ↓
+Countermeasure: Manage with a 3-layer structure (Immutable, Semi-stable, Variable)
+  ↓
+Result: Enables more systematic character design.
 ```
 
 ---
 
-## 🔄 原則3：段階的構築の原則
-**複雑なタスクを小さなステップに分解**
+## 🔄 Principle 3: Principle of Incremental Construction
+**Break down complex tasks into small steps.**
 
-### ステップ分解の例
+### Example of Step Decomposition
 
-#### キャラクター作成
+#### Character Creation
 ```
-Step 1: 基本属性（名前、年齢、職業）
-　↓
-Step 2: 核となる価値観
-　↓
-Step 3: 価値観から派生する恐れ
-　↓
-Step 4: 人間的な矛盾
-　↓
-Step 5: 具体的な行動パターン
-```
-
-#### 物語構築
-```
-Step 1: 一文でのあらすじ
-　↓
-Step 2: 3幕構成の概要
-　↓
-Step 3: 重要シーンの選定
-　↓
-Step 4: 各シーンの詳細設計
-　↓
-Step 5: シーン間の繋ぎ
+Step 1: Basic attributes (name, age, occupation)
+  ↓
+Step 2: Core value
+  ↓
+Step 3: Fear derived from value
+  ↓
+Step 4: Human contradiction
+  ↓
+Step 5: Specific behavior patterns
 ```
 
-### 段階的構築のメリット
-1. **品質管理**：各段階で確認・修正が可能
-2. **柔軟性**：途中での方向転換が容易
-3. **理解度向上**：AIが文脈を保持しやすい
-4. **再利用性**：各段階の成果を他に応用可能
+#### Story Construction
+```
+Step 1: One-sentence synopsis
+  ↓
+Step 2: Overview of 3-act structure
+  ↓
+Step 3: Selection of important scenes
+  ↓
+Step 4: Detailed design of each scene
+  ↓
+Step 5: Transitions between scenes
+```
+
+### Advantages of Incremental Construction
+1. **Quality Control**: Allows for confirmation and correction at each stage.
+2. **Flexibility**: Easy to change direction midway.
+3. **Improved Understanding**: Easier for AI to maintain context.
+4. **Reusability**: Results from each stage can be applied elsewhere.
 
 ---
 
-## 📌 原則4：文脈保持の原則
-**重要な情報を適切に配置し、一貫性を保つ**
+## 📌 Principle 4: Principle of Context Retention
+**Place important information appropriately and maintain consistency.**
 
-### 文脈保持のテクニック
+### Context Retention Techniques
 
-#### 1. サンドイッチ構造
+#### 1. Sandwich Structure
 ```
-[重要な設定・ルール]
-　　　↓
-[詳細な内容・展開]
-　　　↓
-[重要な設定の再確認]
+[Important settings/rules]
+      ↓
+[Detailed content/development]
+      ↓
+[Reconfirmation of important settings]
 ```
 
-#### 2. アンカーポイント設置
-各セクションの冒頭に、以下を配置：
-- キャラクターの核となる価値観
-- 現在の場所と時間
-- 直前の出来事の要約
+#### 2. Setting Anchor Points
+At the beginning of each section, place:
+- Character's core value
+- Current location and time
+- Summary of immediately preceding events
 
-#### 3. 構造化フォーマット
+#### 3. Structured Format
 ```markdown
-## シーン情報
-- 場所：[具体的な場所]
-- 時間：[時刻・天候]
-- 登場人物：[誰がいるか]
+## Scene Information
+- Location: [Specific location]
+- Time: [Time of day/Weather]
+- Characters: [Who is present]
 
-## 前シーンからの流れ
-[簡潔な要約]
+## Flow from Previous Scene
+[Concise summary]
 
-## このシーンの目的
-[何を達成するか]
+## Purpose of This Scene
+[What to achieve]
 ```
 
-### 実装例
+### Implementation Example
 ```
-プロンプト構成：
-1. キャラクター設定（200字）
-2. 現在の状況（100字）
-3. 書いてほしいシーン（本文）
-4. 注意事項（50字）
-5. キャラクター設定の再掲（100字）
+Prompt Structure:
+1. Character settings (200 characters)
+2. Current situation (100 characters)
+3. Scene to be written (main text)
+4. Important notes (50 characters)
+5. Restatement of character settings (100 characters)
 ```
 
 ---
 
-## ✅ 原則5：検証可能性の原則
-**出力の品質を客観的に評価できる仕組み**
+## ✅ Principle 5: Principle of Verifiability
+**A mechanism to objectively evaluate the quality of output.**
 
-### 評価基準の設定
+### Setting Evaluation Criteria
 
-#### 定量的評価
-1. **文字数**：指定範囲内か
-2. **構成要素**：必須要素が含まれているか
-3. **一貫性スコア**：矛盾の数をカウント
-4. **可読性指標**：文の長さ、段落構成
+#### Quantitative Evaluation
+1. **Character Count**: Within the specified range?
+2. **Structural Elements**: Are essential elements included?
+3. **Consistency Score**: Count the number of contradictions.
+4. **Readability Index**: Sentence length, paragraph structure.
 
-#### 定性的評価
-1. **感情曲線**：意図した感情変化があるか
-2. **キャラクター性**：らしさが出ているか
-3. **テーマ性**：主題が表現されているか
-4. **完成度**：物語として成立しているか
+#### Qualitative Evaluation
+1. **Emotional Curve**: Is the intended emotional change present?
+2. **Characterization**: Is the "likeness" evident?
+3. **Thematic Relevance**: Is the main theme expressed?
+4. **Completeness**: Does it work as a story?
 
-### チェックリストの活用
+### Utilizing Checklists
 ```markdown
-シーン評価：
-- [ ] 主人公の価値観に沿った行動か
-- [ ] 時間・場所の整合性は取れているか
-- [ ] 感情の変化は自然か
-- [ ] 次のシーンへの橋渡しはあるか
-- [ ] 読者が状況を理解できるか
+Scene Evaluation:
+- [ ] Actions aligned with the protagonist's values?
+- [ ] Consistency of time and place?
+- [ ] Are emotional changes natural?
+- [ ] Is there a bridge to the next scene?
+- [ ] Can the reader understand the situation?
 ```
 
-### 反復改善プロセス
+### Iterative Improvement Process
 ```
-1. 初稿生成
-　↓
-2. チェックリスト評価
-　↓
-3. 問題点の特定
-　↓
-4. 修正プロンプト作成
-　↓
-5. 再生成
-　↓
-6. 比較評価
-```
-
----
-
-## 🎯 5原則の統合的活用
-
-### 実践例：短編小説の作成
-
-**Step 1：明確な指示**（原則1）
-```
-5000字の短編小説を書いてください。
-ジャンル：ヒューマンドラマ
-テーマ：過去との和解
-```
-
-**Step 2：制約の考慮**（原則2）
-```
-重要な設定は冒頭に配置
-複雑な時系列は避ける
-場所は3箇所以内に限定
-```
-
-**Step 3：段階的作成**（原則3）
-```
-Phase 1: プロット作成（500字）
-Phase 2: 重要シーン3つの詳細（各300字）
-Phase 3: 全体の執筆（5000字）
-```
-
-**Step 4：文脈の維持**（原則4）
-```
-各シーンの冒頭で：
-- 主人公の現在の感情
-- 場所と時間
-- 直前の出来事
-を明示
-```
-
-**Step 5：品質検証**（原則5）
-```
-評価項目：
-✓ 文字数：4800字（目標の96%）
-✓ キャラクター一貫性：8/10
-✓ 感情の流れ：自然
-✓ テーマの表現：明確
+1. Generate first draft
+  ↓
+2. Evaluate with checklist
+  ↓
+3. Identify problem areas
+  ↓
+4. Create revised prompt
+  ↓
+5. Regenerate
+  ↓
+6. Comparative evaluation
 ```
 
 ---
 
-## 📚 原則の深い理解のために
+## 🎯 Integrated Application of the 5 Principles
 
-### 練習問題
+### Practical Example: Creating a Short Story
 
-#### 練習1：明確性の向上
-以下のプロンプトを改善してください：
-「悲しい話を書いて」
+**Step 1: Clear Instructions** (Principle 1)
+```
+Please write a 5000-character short story.
+Genre: Human Drama
+Theme: Reconciliation with the past
+```
 
-#### 練習2：制約の活用
-10,000字の物語を、Lost in the Middle現象を考慮して構成してください。
+**Step 2: Consideration of Constraints** (Principle 2)
+```
+Place important settings at the beginning.
+Avoid complex timelines.
+Limit locations to three or fewer.
+```
 
-#### 練習3：段階的構築
-「宇宙船での殺人事件」を5つのステップで構築してください。
+**Step 3: Incremental Creation** (Principle 3)
+```
+Phase 1: Plot creation (500 characters)
+Phase 2: Details of 3 important scenes (300 characters each)
+Phase 3: Writing the whole story (5000 characters)
+```
 
-#### 練習4：文脈保持
-3つのシーンを跨いで、主人公の価値観を一貫させる方法を設計してください。
+**Step 4: Context Retention** (Principle 4)
+```
+At the beginning of each scene, specify:
+- Protagonist's current emotion
+- Location and time
+- Immediately preceding events
+```
 
-#### 練習5：検証可能性
-ミステリー小説の品質を評価する5つの客観的指標を設定してください。
+**Step 5: Quality Verification** (Principle 5)
+```
+Evaluation Items:
+✓ Character count: 4800 characters (96% of target)
+✓ Character consistency: 8/10
+✓ Flow of emotions: Natural
+✓ Expression of theme: Clear
+```
 
 ---
 
-## 🔮 今後の展望
+## 📚 For a Deeper Understanding of the Principles
 
-### AIの進化と原則の関係
-- モデルが進化しても、5原則は有効
-- 制約が変わっても、考え方は応用可能
-- より高度な創作への適用
+### Practice Exercises
 
-### 新しい可能性
-1. **マルチモーダル**：画像＋文章での物語創作
-2. **インタラクティブ**：読者の選択で変化する物語
-3. **協調創作**：複数のAIとの共同作業
+#### Exercise 1: Improving Clarity
+Improve the following prompt:
+"Write a sad story."
+
+#### Exercise 2: Utilizing Constraints
+Structure a 10,000-character story considering the Lost in the Middle phenomenon.
+
+#### Exercise 3: Incremental Construction
+Construct "a murder case on a spaceship" in 5 steps.
+
+#### Exercise 4: Context Retention
+Design a method to maintain the protagonist's values consistently across three scenes.
+
+#### Exercise 5: Verifiability
+Set five objective indicators for evaluating the quality of a mystery novel.
 
 ---
 
-💡 **Remember**: これらの原則は道具です。創造性を制限するものではなく、より良い作品を生み出すための指針として活用してください。
+## 🔮 Future Outlook
+
+### Relationship between AI Evolution and Principles
+- The 5 principles remain valid even as models evolve.
+- Even if constraints change, the way of thinking can be applied.
+- Application to more advanced creation.
+
+### New Possibilities
+1. **Multimodal**: Story creation with images + text.
+2. **Interactive**: Stories that change based on reader choices.
+3. **Collaborative Creation**: Joint work with multiple AIs.
+
+---
+
+💡 **Remember**: These principles are tools. Use them as guidelines for creating better works, not to limit creativity.

--- a/resources/workflow.md
+++ b/resources/workflow.md
@@ -1,295 +1,295 @@
-# 推奨ワークフロー
+# Recommended Workflow
 
-## 🗓️ 3週間集中創作プログラム
+## 🗓️ 3-Week Intensive Creation Program
 
-### Week 1: キャラクター確立
+### Week 1: Character Establishment
 
-#### Day 1-2: 主人公の創造
-**目標**：魅力的で一貫性のある主人公を作る
+#### Day 1-2: Protagonist Creation
+**Goal**: Create a compelling and consistent protagonist.
 
 ```
-タイムテーブル：
-09:00-09:30 CHARACTER.mdを読み込み、理解
-09:30-10:30 基本情報記入とブレインストーミング
-10:30-11:30 AIとの対話（5ステップ法）
-11:30-12:00 一貫性チェックと修正
+Timetable:
+09:00-09:30 Read and understand CHARACTER.md
+09:30-10:30 Fill in basic information and brainstorm
+10:30-11:30 Dialogue with AI (5-step method)
+11:30-12:00 Consistency check and revisions
 ```
 
-**使用ツール**：
+**Tools to use**:
 - `character-template/CHARACTER.md`
 - `character-template/character-prompts.md`
-- お好みのAI（Claude, ChatGPT等）
+- Your preferred AI (Claude, ChatGPT, etc.)
 
-#### Day 3-4: サブキャラクターの設計
-**目標**：主人公を引き立てる脇役を作る
+#### Day 3-4: Design of Sub-characters
+**Goal**: Create supporting characters that complement the protagonist.
 
-チェックリスト：
-- [ ] 主人公との関係性を明確に
-- [ ] それぞれ異なる価値観を設定
-- [ ] 役割分担を明確に
+Checklist:
+- [ ] Clarify relationship with the protagonist
+- [ ] Set different values for each
+- [ ] Clarify role division
 
-#### Day 5-6: キャラクター相関図
-**目標**：人間関係のダイナミクスを設計
+#### Day 5-6: Character Correlation Diagram
+**Goal**: Design the dynamics of human relationships.
 
 ```mermaid
 graph TD
-    A[主人公] -->|信頼| B[親友]
-    A -->|対立| C[ライバル]
-    A -->|憧れ| D[メンター]
-    B -->|嫉妬| C
+    A[Protagonist] -->|Trust| B[Best Friend]
+    A -->|Conflict| C[Rival]
+    A -->|Admiration| D[Mentor]
+    B -->|Jealousy| C
 ```
 
-#### Day 7: 週次レビュー
-- キャラクターの魅力度評価
-- 設定の整合性確認
-- 次週への準備
+#### Day 7: Weekly Review
+- Evaluate character appeal
+- Confirm setting consistency
+- Prepare for the next week
 
 ---
 
-### Week 2: 物語構築
+### Week 2: Story Construction
 
-#### Day 8-9: プロット作成
-**目標**：骨太な物語の骨組みを作る
+#### Day 8-9: Plot Creation
+**Goal**: Create a solid story framework.
 
 ```
-作業手順：
-1. STORY.md Phase 1を完成
-2. テーマを明確に言語化
-3. 3幕構成を詳細化
-4. 起承転結の確認
+Work Procedure:
+1. Complete STORY.md Phase 1
+2. Clearly verbalize the theme
+3. Detail the 3-act structure
+4. Confirm the story arc (beginning, development, turn, conclusion)
 ```
 
-#### Day 10-11: 重要シーンの特定
-**目標**：物語の山場を明確にする
+#### Day 10-11: Identification of Important Scenes
+**Goal**: Clarify the story's high points.
 
-重要シーンの基準：
-- 🎭 感情が大きく動く
-- 🔄 物語が転換する
-- 💡 テーマが表現される
-- 🎯 読者の期待に応える
+Criteria for important scenes:
+- 🎭 Emotions run high
+- 🔄 The story takes a turn
+- 💡 The theme is expressed
+- 🎯 Meets reader expectations
 
-#### Day 12-13: シーン詳細設計
-**目標**：各シーンを映像的に構築
+#### Day 12-13: Detailed Scene Design
+**Goal**: Construct each scene visually.
 
 ```yaml
-シーン設計シート:
-  外的要素:
-    場所: 具体的に
-    時間: 明確に
-    天候: 雰囲気作り
-  内的要素:
-    感情: 変化を追う
-    葛藤: 明確に
-    決断: 具体的に
+Scene Design Sheet:
+  External Elements:
+    Location: Specific
+    Time: Clear
+    Weather: Atmosphere creation
+  Internal Elements:
+    Emotion: Track changes
+    Conflict: Clear
+    Decision: Specific
 ```
 
-#### Day 14: 週次レビュー
-- プロットの完成度確認
-- ペース配分の検証
-- 執筆準備の最終確認
+#### Day 14: Weekly Review
+- Confirm plot completeness
+- Verify pacing
+- Final check of writing preparations
 
 ---
 
-### Week 3: 執筆と改善
+### Week 3: Writing and Improvement
 
-#### Day 15-17: 第一稿執筆
-**目標**：完璧を求めず、最後まで書き切る
+#### Day 15-17: First Draft Writing
+**Goal**: Write to the end without aiming for perfection.
 
 ```
-執筆リズム:
+Writing Rhythm:
 ━━━━━━━━━━━━━━━━━━━
-09:00-11:00 執筆（2時間）
-11:00-11:15 休憩
-11:15-12:15 執筆（1時間）
+09:00-11:00 Writing (2 hours)
+11:00-11:15 Break
+11:15-12:15 Writing (1 hour)
 ━━━━━━━━━━━━━━━━━━━
-目標: 1日1,500-2,000字
+Goal: 1,500-2,000 characters per day
 ```
 
-**執筆のコツ**：
-- 編集しながら書かない
-- 疑問点はメモして進む
-- リズムを大切に
+**Writing Tips**:
+- Don't edit while writing.
+- Note down questions and move on.
+- Value rhythm.
 
-#### Day 18-19: 品質チェック
-**目標**：客観的に作品を評価
+#### Day 18-19: Quality Check
+**Goal**: Evaluate the work objectively.
 
-使用ツール：
+Tools to use:
 - `quality-check/checklist.md`
-- 5軸評価（各10点満点）
-- 改善点の優先順位付け
+- 5-axis evaluation (max 10 points each)
+- Prioritize areas for improvement.
 
-#### Day 20: 修正と仕上げ
-**目標**：重要な問題を解決
+#### Day 20: Revision and Finishing
+**Goal**: Solve important problems.
 
-修正の優先順位：
-1. ❗ キャラクターの一貫性
-2. ❗ 物語の論理性
-3. ⚠️ 文章の読みやすさ
-4. 💭 細部の調整
+Revision Priority:
+1. ❗ Character consistency
+2. ❗ Story logic
+3. ⚠️ Readability of text
+4. 💭 Fine-tuning details
 
-#### Day 21: 最終確認
-- 通し読みで全体確認
-- タイトルの最終決定
-- 完成の喜びを味わう
+#### Day 21: Final Confirmation
+- Read through the entire work for a final check.
+- Finalize the title.
+- Savor the joy of completion.
 
 ---
 
-## 🔄 継続的改善サイクル
+## 🔄 Continuous Improvement Cycle
 
-### 日次ルーティン（執筆期）
+### Daily Routine (During Writing Phase)
 
 ```
-朝のルーティン（30分）:
-1. 前日の内容を読み返す
-2. 今日の目標を設定
-3. キャラクター設定を確認
-4. 執筆開始
+Morning Routine (30 minutes):
+1. Reread the previous day's content.
+2. Set today's goals.
+3. Review character settings.
+4. Start writing.
 
-夜のルーティン（30分）:
-1. 今日書いた分を読み返す
-2. 良かった点を3つ記録
-3. 改善点を1つメモ
-4. 明日の準備
+Evening Routine (30 minutes):
+1. Reread what was written today.
+2. Record 3 things that went well.
+3. Note down 1 point for improvement.
+4. Prepare for tomorrow.
 ```
 
-### 週次レビューテンプレート
+### Weekly Review Template
 
 ```markdown
-## Week [N] レビュー
+## Week [N] Review
 
-### 達成したこと
+### Accomplishments
 - 
-- 
-- 
-
-### うまくいったこと
 - 
 - 
 
-### 課題と対策
-| 課題 | 原因 | 対策 |
-|------|------|------|
-|      |      |      |
+### What Went Well
+- 
+- 
 
-### 来週の目標
+### Challenges and Countermeasures
+| Challenge | Cause | Countermeasure |
+|-----------|-------|----------------|
+|           |       |                |
+
+### Goals for Next Week
 1. 
 2. 
 3. 
 
-### 気づきとメモ
+### Insights and Memos
 ```
 
 ---
 
-## 🛠️ ツール活用ガイド
+## 🛠️ Tool Usage Guide
 
-### Phase別推奨ツール
+### Recommended Tools by Phase
 
-#### 構想期
-- **マインドマップ**: アイデア整理
-- **Pinterest**: ビジュアルイメージ
-- **音楽**: 雰囲気作り
+#### Conceptualization Phase
+- **Mind Map**: Idea organization
+- **Pinterest**: Visual inspiration
+- **Music**: Atmosphere creation
 
-#### 執筆期
-- **ポモドーロタイマー**: 集中力維持
-- **Character.ai**: 対話シミュレーション
-- **DeepL Write**: 文章推敲
+#### Writing Phase
+- **Pomodoro Timer**: Maintain focus
+- **Character.ai**: Dialogue simulation
+- **DeepL Write**: Text revision
 
-#### 推敲期
-- **読み上げソフト**: 客観的確認
-- **印刷**: 紙での確認
-- **共有**: フィードバック収集
+#### Revision Phase
+- **Text-to-speech software**: Objective review
+- **Printing**: Review on paper
+- **Sharing**: Feedback collection
 
 ---
 
-## 💡 創作のコツ
+## 💡 Creation Tips
 
-### 行き詰まった時の対処法
+### How to Deal with Writer's Block
 
-#### 1. キャラクターと対話
+#### 1. Converse with the Character
 ```
-プロンプト例：
-「あなたは[キャラクター名]です。
-今、[状況]にいます。
-何を考えていますか？」
-```
-
-#### 2. 視点を変える
-- 別キャラクターの視点で見る
-- 読者の立場で読み返す
-- 1週間寝かせる
-
-#### 3. 制約を加える
-- 文字数を半分に
-- 別ジャンルで書き直す
-- 5分で要約する
-
-### モチベーション維持
-
-#### 進捗の可視化
-```
-執筆カレンダー:
-月 火 水 木 金 土 日
-✓  ✓  ✓  ✓  ✓  ✓  ✓
-↑毎日少しでも書いたら✓
+Example Prompt:
+"You are [Character Name].
+You are currently in [situation].
+What are you thinking?"
 ```
 
-#### 小さな報酬
-- 1,000字書いたら好きな飲み物
-- 1章完成したら映画鑑賞
-- 完成したら自分へのご褒美
+#### 2. Change Perspective
+- See from another character's point of view.
+- Reread from the reader's standpoint.
+- Let it sit for a week.
+
+#### 3. Add Constraints
+- Halve the character count.
+- Rewrite in a different genre.
+- Summarize in 5 minutes.
+
+### Maintaining Motivation
+
+#### Visualize Progress
+```
+Writing Calendar:
+Mon Tue Wed Thu Fri Sat Sun
+✓   ✓   ✓   ✓   ✓   ✓   ✓
+↑ Check if you wrote even a little each day
+```
+
+#### Small Rewards
+- Favorite drink after writing 1,000 characters.
+- Watch a movie after completing a chapter.
+- Treat yourself upon completion.
 
 ---
 
-## 📈 スキルアップの道
+## 📈 Path to Skill Improvement
 
-### Level 1: 基礎固め（1-3作品目）
-- テンプレートに従って書く
-- 短編から始める
-- 完成を最優先
+### Level 1: Solidifying Basics (1st-3rd work)
+- Write according to the template.
+- Start with short stories.
+- Prioritize completion.
 
-### Level 2: 応用展開（4-10作品目）
-- テンプレートをカスタマイズ
-- 中編に挑戦
-- 複数キャラクターの管理
+### Level 2: Applied Development (4th-10th work)
+- Customize templates.
+- Try writing medium-length stories.
+- Manage multiple characters.
 
-### Level 3: 独自スタイル（11作品目以降）
-- 自分だけのテンプレート作成
-- 長編への挑戦
-- ジャンルの融合
-
----
-
-## 🎯 成功指標
-
-### 定量的指標
-- [ ] 予定通り完成したか
-- [ ] 目標文字数を達成したか
-- [ ] 品質スコア40点以上か
-
-### 定性的指標
-- [ ] 書いていて楽しかったか
-- [ ] キャラクターが生きていたか
-- [ ] 伝えたいことが伝わったか
-- [ ] また書きたいと思うか
+### Level 3: Unique Style (11th work onwards)
+- Create your own templates.
+- Challenge yourself with long-form stories.
+- Fuse genres.
 
 ---
 
-## 🚀 次のステップ
+## 🎯 Success Indicators
 
-### 作品完成後のアクション
-1. **1週間寝かせる** - 客観性を取り戻す
-2. **推敲と修正** - 品質向上
-3. **共有** - フィードバックを得る
-4. **振り返り** - 学びを記録
-5. **次回作の構想** - 継続が力
+### Quantitative Indicators
+- [ ] Was it completed on schedule?
+- [ ] Was the target character count achieved?
+- [ ] Is the quality score 40 points or higher?
 
-### コミュニティ活用
-- 作品を共有する勇気
-- 他者の作品から学ぶ
-- 創作仲間を見つける
-- 切磋琢磨する環境
+### Qualitative Indicators
+- [ ] Was it enjoyable to write?
+- [ ] Did the characters feel alive?
+- [ ] Was the intended message conveyed?
+- [ ] Do you want to write again?
 
 ---
 
-🌟 **Remember**: 完璧な第一稿はありません。大切なのは、書き始め、書き続け、書き終えること。そして、次へ進むことです。
+## 🚀 Next Steps
+
+### Actions After Completing a Work
+1. **Let it sit for 1 week** - To regain objectivity.
+2. **Revise and correct** - Improve quality.
+3. **Share** - Get feedback.
+4. **Reflect** - Record learnings.
+5. **Plan next work** - Continuation is power.
+
+### Utilizing the Community
+- Courage to share your work.
+- Learn from others' works.
+- Find creative companions.
+- An environment for friendly competition.
+
+---
+
+🌟 **Remember**: There is no perfect first draft. What's important is to start writing, keep writing, and finish writing. And then, to move on to the next thing.

--- a/story-template/STORY.md
+++ b/story-template/STORY.md
@@ -1,103 +1,103 @@
-# 物語構築シート
+# Story Construction Sheet
 
-## 基本設定
-**タイトル**：  
-**ジャンル**：  
-**想定文字数**：  
-**一言で表すと**：  
+## Basic Settings
+**Title**:
+**Genre**:
+**Estimated Character Count**:
+**In a nutshell**:
 
 ---
 
-## Phase 1: 骨組み（スケルトン）
+## Phase 1: Skeleton
 
-### コアとなる要素
-**主人公**：[CHARACTER.mdから引用]  
-**中心となるテーマ**：  
-**物語の始まりと終わり**：
-- 始まり：  
-- 終わり：  
+### Core Elements
+**Protagonist**: [Quote from CHARACTER.md]
+**Central Theme**:
+**Beginning and End of the Story**:
+- Beginning:
+- End:
 
-### 3幕構成（各3行程度）
-**第1幕（設定）**：  
+### 3-Act Structure (Approx. 3 lines each)
+**Act 1 (Setup)**:
 1. 
 2. 
 3. 
 
-**第2幕（展開）**：  
+**Act 2 (Confrontation)**:
 1. 
 2. 
 3. 
 
-**第3幕（解決）**：  
+**Act 3 (Resolution)**:
 1. 
 2. 
 3. 
 
 ---
 
-## Phase 2: 重要シーンの特定
+## Phase 2: Identify Important Scenes
 
-### 物語の3つの柱となるシーン
+### Three Pillar Scenes of the Story
 
-#### 1. 転換点シーン
-**場所・時間**：  
-**何が起こるか**：  
-**主人公の変化**：  
+#### 1. Turning Point Scene
+**Location/Time**:
+**What happens**:
+**Protagonist's change**:
 
-#### 2. 感情のピークシーン  
-**場所・時間**：  
-**何が起こるか**：  
-**読者に感じてほしいこと**：  
+#### 2. Emotional Peak Scene
+**Location/Time**:
+**What happens**:
+**What you want the reader to feel**:
 
-#### 3. テーマ体現シーン
-**場所・時間**：  
-**何が起こるか**：  
-**テーマとの関連**：  
+#### 3. Theme Embodiment Scene
+**Location/Time**:
+**What happens**:
+**Relation to the theme**:
 
 ---
 
-## Phase 3: シーンの詳細設計
+## Phase 3: Detailed Scene Design
 
-### シーン1：[シーン名]
+### Scene 1: [Scene Name]
 
-**外的状況**：  
-- 場所：  
-- 時間：  
-- 登場人物：  
+**External Situation**:
+- Location:
+- Time:
+- Characters Present:
 
-**内的状況**：  
-- 主人公の感情：  
-- 望んでいること：  
-- 恐れていること：  
+**Internal Situation**:
+- Protagonist's emotion:
+- Desired outcome:
+- Feared outcome:
 
-**シーンの流れ**：
-1. 導入：  
-2. 展開：  
-3. 転換：  
-4. 締め：  
+**Scene Flow**:
+1. Introduction:
+2. Development:
+3. Turning Point:
+4. Conclusion:
 
-**このシーンで必ず描くこと**：  
+**Must-depict elements in this scene**:
 - [ ] 
 - [ ] 
 - [ ] 
 
 ---
 
-## 品質チェック
+## Quality Check
 
-### ストーリー全体
-- [ ] 主人公の価値観は一貫しているか？
-- [ ] 物理的な矛盾はないか？
-- [ ] 感情の流れは自然か？
-- [ ] テーマは効果的に表現されているか？
-- [ ] 読者を引き込む工夫はあるか？
+### Overall Story
+- [ ] Is the protagonist's value consistent?
+- [ ] Are there any physical contradictions?
+- [ ] Is the flow of emotions natural?
+- [ ] Is the theme effectively expressed?
+- [ ] Are there devices to draw the reader in?
 
-### 要注意ポイント
-- [ ] Lost in the Middle対策：重要情報は冒頭か結末に
-- [ ] 物理描写は最小限に、心理描写を重視
-- [ ] 各シーンに明確な役割があるか
+### Key Points to Watch
+- [ ] Lost in the Middle countermeasure: Important information at the beginning or end.
+- [ ] Minimize physical descriptions, emphasize psychological descriptions.
+- [ ] Does each scene have a clear role?
 
 ---
 
-## メモ・アイデア
-（自由記述欄）
+## Memos/Ideas
+(Free description field)

--- a/story-template/examples/chapter-example.md
+++ b/story-template/examples/chapter-example.md
@@ -91,7 +91,7 @@
 ### Chapter 7: "Hidden Truth"
 - Possibility that the accident was not simple.
 - Discovery of a message Sho left just before his death.
-- New facts浮かび上がる (emerging) from Digital Sho's memories.
+New facts emerging from Digital Sho's memories.
 
 ### Chapter 8: "Dialogue by the Sea"
 - "Confession of Truth" scene.

--- a/story-template/examples/chapter-example.md
+++ b/story-template/examples/chapter-example.md
@@ -1,181 +1,181 @@
-# 物語構築シート - 章立て小説の例「デジタル・ゴースト」
+# Story Construction Sheet - Example of a Chaptered Novel "Digital Ghost"
 
-## 基本設定
-**タイトル**：デジタル・ゴースト  
-**ジャンル**：近未来SF × ミステリー  
-**想定文字数**：40,000字（10章構成）  
-**一言で表すと**：「AIに死者の記憶を移植した時、そこに宿るのは本人なのか」  
-
----
-
-## Phase 1: 骨組み（スケルトン）
-
-### コアとなる要素
-**主人公**：桜井葵（32歳・AI研究者）- 「テクノロジーで人の悲しみを癒したい」  
-**中心となるテーマ**：アイデンティティの本質と、手放すことの大切さ  
-**物語の始まりと終わり**：
-- 始まり：亡き恋人の記憶をAIに移植するプロジェクトが始動する  
-- 終わり：本物の愛とは、相手を手放す勇気を持つことだと悟る  
-
-### 3幕構成（各3行程度）
-**第1幕（設定）第1-3章**：  
-1. 事故で恋人・翔を失った葵は、彼の記憶をAIに移植する研究に没頭している
-2. ついに翔の記憶を持つAI「デジタル翔」が完成し、会話が可能になる
-3. しかし、デジタル翔は徐々に生前の翔とは異なる反応を示し始める
-
-**第2幕（展開）第4-8章**：  
-1. デジタル翔が、生前の翔が知らないはずの情報を話し始める
-2. 調査の結果、AIが複数の人物の記憶を混在させていることが判明
-3. さらに、翔の死に隠された真実が明らかになっていく
-
-**第3幕（解決）第9-10章**：  
-1. 葵は、本物の翔を取り戻すことは不可能だと受け入れる
-2. デジタル翔自身も、自分の存在の意味を問い始める
-3. 最後に葵は、デジタル翔を消去し、新たな人生を歩み始める
+## Basic Settings
+**Title**: Digital Ghost
+**Genre**: Near-Future Sci-Fi x Mystery
+**Estimated Character Count**: 40,000 characters (10-chapter structure)
+**In a nutshell**: "When a deceased person's memories are transplanted into an AI, is the entity that resides there the person themselves?"
 
 ---
 
-## Phase 2: 重要シーンの特定
+## Phase 1: Skeleton
 
-### 物語の3つの柱となるシーン
+### Core Elements
+**Protagonist**: Aoi Sakurai (32 years old, AI researcher) - "I want to heal people's sorrow with technology."
+**Central Theme**: The essence of identity and the importance of letting go.
+**Beginning and End of the Story**:
+- Beginning: A project to transplant her deceased lover's memories into an AI begins.
+- End: She realizes that true love means having the courage to let the other person go.
 
-#### 1. 転換点シーン「最初の違和感」（第3章）
-**場所・時間**：研究所のAIルーム・深夜2時  
-**何が起こるか**：デジタル翔が、生前の翔が嫌いだった音楽を「懐かしい」と言う  
-**主人公の変化**：完璧な再現への確信が、初めて揺らぐ  
+### 3-Act Structure (Approx. 3 lines each)
+**Act 1 (Setup) Chapters 1-3**:
+1. Aoi, who lost her lover Sho in an accident, immerses herself in research to transplant his memories into an AI.
+2. "Digital Sho," an AI possessing Sho's memories, is finally completed, enabling conversation.
+3. However, Digital Sho gradually begins to show reactions different from the Sho of when he was alive.
 
-#### 2. 感情のピークシーン「真実の告白」（第8章）  
-**場所・時間**：翔と最後に行った海辺・夕暮れ  
-**何が起こるか**：デジタル翔が、事故の真相と翔の最期の想いを語る  
-**読者に感じてほしいこと**：真実の重さと、それでも前に進む勇気  
+**Act 2 (Confrontation) Chapters 4-8**:
+1. Digital Sho starts talking about information that the living Sho shouldn't have known.
+2. Investigation reveals that the AI is mixing memories of multiple individuals.
+3. Furthermore, the hidden truth about Sho's death begins to come to light.
 
-#### 3. テーマ体現シーン「最後の別れ」（第10章）
-**場所・時間**：研究所・朝焼けの光が差し込む時間  
-**何が起こるか**：葵がデジタル翔のデータを消去する決断をする  
-**テーマとの関連**：本当の愛は、執着ではなく解放にある  
-
----
-
-## 章構成詳細
-
-### 第1章：「記憶の器」
-- 葵の日常と、翔を失った悲しみの描写
-- AI記憶移植プロジェクトの説明
-- チームメンバーの紹介と、それぞれの動機
-
-### 第2章：「覚醒」
-- デジタル翔の起動シーン
-- 最初の会話と、葵の感動
-- しかし、微妙な違和感も描写
-
-### 第3章：「ずれ」
-- デジタル翔との日常会話
-- 小さな記憶の食い違いが蓄積していく
-- 「最初の違和感」シーン
-
-### 第4章：「疑念」
-- 葵が違和感の原因を調査開始
-- AIのログ解析で異常なパターンを発見
-- 同僚の反対を押し切って深堀りを決意
-
-### 第5章：「混在」
-- 他人の記憶が混入している証拠を発見
-- デジタル翔自身も自分の記憶に疑問を持ち始める
-- 倫理委員会からの警告
-
-### 第6章：「過去の影」
-- 翔の事故について再調査を開始
-- 警察記録に不自然な点を発見
-- デジタル翔が見せる、説明のつかない感情
-
-### 第7章：「隠された真実」
-- 事故は単純な事故ではなかった可能性
-- 翔が死の直前に残したメッセージの発見
-- デジタル翔の記憶から浮かび上がる新事実
-
-### 第8章：「海辺の対話」
-- 「真実の告白」シーン
-- 翔の本当の想いと、葵への最後のメッセージ
-- デジタル翔が示す、AIとしての自我
-
-### 第9章：「選択」
-- プロジェクトの終了を決意する葵
-- チームメンバーとの対立と和解
-- デジタル翔との最後の一日
-
-### 第10章：「新しい朝」
-- 「最後の別れ」シーン
-- データ消去と、その瞬間の描写
-- 数ヶ月後、新たな研究を始める葵
+**Act 3 (Resolution) Chapters 9-10**:
+1. Aoi accepts that it is impossible to get the real Sho back.
+2. Digital Sho itself begins to question the meaning of its own existence.
+3. Finally, Aoi decides to erase Digital Sho and starts a new life.
 
 ---
 
-## キャラクター相関
+## Phase 2: Identify Important Scenes
 
-### 主要人物
-- **桜井葵**：主人公、AI研究者
-- **翔**（本物）：葵の恋人、1年前に事故死
-- **デジタル翔**：翔の記憶を持つAI
-- **北村教授**：葵の指導教官、プロジェクトリーダー
-- **白石ユナ**：同僚研究者、倫理的な懸念を持つ
+### Three Pillar Scenes of the Story
 
-### 関係性の変化
-- 葵 → デジタル翔：依存 → 疑念 → 理解 → 解放
-- デジタル翔 → 葵：プログラムされた愛 → 真の思いやり
-- ユナ → 葵：心配 → 対立 → 支援
+#### 1. Turning Point Scene "The First Discomfort" (Chapter 3)
+**Location/Time**: AI room at the research institute, 2:00 AM.
+**What happens**: Digital Sho says music that the living Sho disliked is "nostalgic."
+**Protagonist's change**: Her conviction of perfect replication wavers for the first time.
 
----
+#### 2. Emotional Peak Scene "Confession of Truth" (Chapter 8)
+**Location/Time**: The seaside where she last went with Sho, dusk.
+**What happens**: Digital Sho recounts the truth of the accident and Sho's final thoughts.
+**What you want the reader to feel**: The weight of truth and the courage to move forward despite it.
 
-## 品質チェック
-
-### ストーリー全体
-- [x] 主人公の価値観は一貫しているか？
-- [x] 物理的な矛盾はないか？（SF設定の範囲内で）
-- [x] 感情の流れは自然か？
-- [x] テーマは効果的に表現されているか？
-- [x] 読者を引き込む工夫はあるか？
-
-### 章ごとのチェック
-- [x] 各章に明確な役割があるか？
-- [x] 章の終わりに次を読みたくなる要素があるか？
-- [x] ペース配分は適切か？
+#### 3. Theme Embodiment Scene "The Final Farewell" (Chapter 10)
+**Location/Time**: Research institute, time when the morning glow shines in.
+**What happens**: Aoi decides to erase Digital Sho's data.
+**Relation to the theme**: True love lies not in attachment, but in liberation.
 
 ---
 
-## メモ・アイデア
+## Detailed Chapter Structure
 
-### 技術設定
-- 記憶移植は脳スキャンデータとSNS、デジタル記録を統合
-- AIは量子コンピュータ上で動作
-- 完全な人格再現は理論上不可能（不確定性原理）
+### Chapter 1: "Vessel of Memory"
+- Depiction of Aoi's daily life and her grief over losing Sho.
+- Explanation of the AI memory transplant project.
+- Introduction of team members and their respective motivations.
 
-### 伏線リスト
-1. 第2章：デジタル翔が知らないはずの子守唄を口ずさむ
-2. 第4章：翔の最後の通話記録が削除されている
-3. 第6章：事故現場の防犯カメラの不自然な故障
+### Chapter 2: "Awakening"
+- Digital Sho's activation scene.
+- First conversation and Aoi's emotional response.
+- However, subtle discomfort is also depicted.
 
-### 象徴的な小道具
-- 翔が葵に贈った万華鏡（記憶の多面性の象徴）
-- 未完成のジグソーパズル（完全な再現の不可能性）
-- 海辺で拾った貝殻（本物の思い出）
+### Chapter 3: "Discrepancy"
+- Daily conversations with Digital Sho.
+- Accumulation of small memory inconsistencies.
+- "The First Discomfort" scene.
 
-### 各章の文字数目安
-- 第1章：5,000字（世界観の説明含む）
-- 第2-9章：各4,000字
-- 第10章：3,000字（簡潔な結末）
+### Chapter 4: "Suspicion"
+- Aoi begins to investigate the cause of the discomfort.
+- Discovers abnormal patterns in AI log analysis.
+- Decides to dig deeper, overriding colleagues' objections.
 
-### AIプロンプト活用例
+### Chapter 5: "Admixture"
+- Discovery of evidence that other people's memories are mixed in.
+- Digital Sho itself begins to question its own memories.
+- Warning from the ethics committee.
+
+### Chapter 6: "Shadow of the Past"
+- Reinvestigation of Sho's accident begins.
+- Unnatural points discovered in police records.
+- Unexplainable emotions shown by Digital Sho.
+
+### Chapter 7: "Hidden Truth"
+- Possibility that the accident was not simple.
+- Discovery of a message Sho left just before his death.
+- New facts浮かび上がる (emerging) from Digital Sho's memories.
+
+### Chapter 8: "Dialogue by the Sea"
+- "Confession of Truth" scene.
+- Sho's true feelings and his final message to Aoi.
+- Digital Sho shows its ego as an AI.
+
+### Chapter 9: "Choice"
+- Aoi decides to terminate the project.
+- Conflict and reconciliation with team members.
+- Last day with Digital Sho.
+
+### Chapter 10: "A New Morning"
+- "The Final Farewell" scene.
+- Data erasure and the depiction of that moment.
+- A few months later, Aoi starts new research.
+
+---
+
+## Character Correlation
+
+### Main Characters
+- **Aoi Sakurai**: Protagonist, AI researcher
+- **Sho (real)**: Aoi's lover, died in an accident 1 year ago
+- **Digital Sho**: AI possessing Sho's memories
+- **Professor Kitamura**: Aoi's supervising professor, project leader
+- **Yuna Shiraishi**: Colleague researcher, has ethical concerns
+
+### Changes in Relationships
+- Aoi → Digital Sho: Dependence → Suspicion → Understanding → Liberation
+- Digital Sho → Aoi: Programmed love → True compassion
+- Yuna → Aoi: Worry → Conflict → Support
+
+---
+
+## Quality Check
+
+### Overall Story
+- [x] Is the protagonist's value consistent?
+- [x] Are there any physical contradictions? (Within the scope of SF settings)
+- [x] Is the flow of emotions natural?
+- [x] Is the theme effectively expressed?
+- [x] Are there devices to draw the reader in?
+
+### Per-Chapter Check
+- [x] Does each chapter have a clear role?
+- [x] Is there an element at the end of the chapter that makes one want to read on?
+- [x] Is the pacing appropriate?
+
+---
+
+## Memos/Ideas
+
+### Technical Settings
+- Memory transplant integrates brain scan data, SNS, and digital records.
+- AI operates on a quantum computer.
+- Perfect personality replication is theoretically impossible (uncertainty principle).
+
+### Foreshadowing List
+1. Chapter 2: Digital Sho hums a lullaby he shouldn't know.
+2. Chapter 4: Sho's last call record is deleted.
+3. Chapter 6: Unnatural malfunction of the security camera at the accident scene.
+
+### Symbolic Props
+- Kaleidoscope Sho gave to Aoi (symbol of the multifaceted nature of memory).
+- Unfinished jigsaw puzzle (impossibility of perfect replication).
+- Seashell picked up at the beach (real memories).
+
+### Estimated Character Count per Chapter
+- Chapter 1: 5,000 characters (including world-building explanation)
+- Chapters 2-9: 4,000 characters each
+- Chapter 10: 3,000 characters (concise ending)
+
+### AI Prompt Usage Example
 ```
-第3章の「最初の違和感」シーンを書いてください。
-設定：
-- 深夜の研究所、葵とデジタル翔が会話している
-- デジタル翔がショパンの曲を「懐かしい」と言う
-- 生前の翔はショパンが苦手だった
-- 葵の内面の動揺を抑制的に描写
-- 1,000字程度で
+Write the "first discomfort" scene from Chapter 3.
+Setting:
+- Late at night in the research lab, Aoi and Digital Sho are talking.
+- Digital Sho says a Chopin piece is "nostalgic."
+- The living Sho disliked Chopin.
+- Describe Aoi's inner turmoil with restraint.
+- Around 1,000 characters.
 ```
 
-### シリーズ化の可能性
-- 続編：他の記憶移植事例を扱う連作
-- スピンオフ：ユナ視点での倫理的葛藤
-- 前日譚：翔と葵の出会いから事故まで
+### Potential for Series
+- Sequel: Series dealing with other memory transplant cases.
+- Spin-off: Ethical dilemmas from Yuna's perspective.
+- Prequel: From Sho and Aoi's first meeting to the accident.

--- a/story-template/examples/short-story-example.md
+++ b/story-template/examples/short-story-example.md
@@ -1,132 +1,132 @@
-# 物語構築シート - 短編小説の例「最後の手紙」
+# Story Construction Sheet - Example of a Short Story "The Last Letter"
 
-## 基本設定
-**タイトル**：最後の手紙  
-**ジャンル**：ヒューマンドラマ  
-**想定文字数**：5,000字  
-**一言で表すと**：「届かなかった手紙が20年後に起こす小さな奇跡」  
-
----
-
-## Phase 1: 骨組み（スケルトン）
-
-### コアとなる要素
-**主人公**：田中美咲（45歳・書店店主）- 「本を通じて人の心に寄り添いたい」  
-**中心となるテーマ**：過去との和解と新たな一歩  
-**物語の始まりと終わり**：
-- 始まり：閉店間際の書店に、見知らぬ老婦人が現れる  
-- 終わり：20年前の手紙が、2つの人生に新しい意味を与える  
-
-### 3幕構成（各3行程度）
-**第1幕（設定）**：  
-1. 経営難に苦しむ書店で、美咲は今日も一人店番をしている
-2. 閉店間際、杖をついた老婦人が「ある本」を探しにやってくる
-3. その本は、美咲の亡き母が最後に仕入れた思い出の一冊だった
-
-**第2幕（展開）**：  
-1. 本を手渡すと、老婦人は涙を流し始める
-2. 実は彼女は、20年前に美咲の母と文通していた元教師だった
-3. 本に挟まれていた未投函の手紙が、二人を結びつける
-
-**第3幕（解決）**：  
-1. 手紙には、母が美咲に伝えたかった想いが綴られていた
-2. 老婦人の言葉で、美咲は書店を続ける意味を再発見する
-3. 新たな決意と共に、書店に温かい光が灯る
+## Basic Settings
+**Title**: The Last Letter
+**Genre**: Human Drama
+**Estimated Character Count**: 5,000 characters
+**In a nutshell**: "A small miracle that an undelivered letter causes 20 years later."
 
 ---
 
-## Phase 2: 重要シーンの特定
+## Phase 1: Skeleton
 
-### 物語の3つの柱となるシーン
+### Core Elements
+**Protagonist**: Misaki Tanaka (45 years old, bookstore owner) - "I want to be close to people's hearts through books."
+**Central Theme**: Reconciliation with the past and a new step forward.
+**Beginning and End of the Story**:
+- Beginning: A strange old woman appears at the bookstore just before closing.
+- End: A 20-year-old letter gives new meaning to two lives.
 
-#### 1. 転換点シーン「本との再会」
-**場所・時間**：薄暗い書店の奥・夕方6時  
-**何が起こるか**：老婦人が探していた本を、美咲が棚の隅で見つける  
-**主人公の変化**：単なる在庫が、母の想い出と繋がる特別な一冊に変わる  
+### 3-Act Structure (Approx. 3 lines each)
+**Act 1 (Setup)**:
+1. Misaki is tending the store alone today in her struggling bookstore.
+2. Just before closing, an old woman with a cane comes looking for "a certain book."
+3. That book was a memorable volume that Misaki's deceased mother last stocked.
 
-#### 2. 感情のピークシーン「手紙の発見」  
-**場所・時間**：書店のカウンター・夕方6時半  
-**何が起こるか**：本のページから、20年前の日付の手紙が落ちる  
-**読者に感じてほしいこと**：時を超えた想いの重さと、偶然の奇跡  
+**Act 2 (Confrontation)**:
+1. When Misaki hands over the book, the old woman begins to cry.
+2. It turns out she was a former teacher who corresponded with Misaki's mother 20 years ago.
+3. An unsent letter tucked into the book connects the two of them.
 
-#### 3. テーマ体現シーン「新たな灯り」
-**場所・時間**：書店の入り口・夜7時  
-**何が起こるか**：美咲が「明日も開店します」の札を掛ける  
-**テーマとの関連**：過去を受け入れ、未来へ歩み出す瞬間  
-
----
-
-## Phase 3: シーンの詳細設計
-
-### シーン1：手紙の発見
-
-**外的状況**：  
-- 場所：古い木製カウンターの前  
-- 時間：夕方6時半、外は既に暗い  
-- 登場人物：美咲、老婦人（山田和子）  
-
-**内的状況**：  
-- 主人公の感情：驚きと懐かしさが入り混じる  
-- 望んでいること：母の想いを知りたい  
-- 恐れていること：期待が裏切られること  
-
-**シーンの流れ**：
-1. 導入：本を包装紙に包もうとした瞬間、手紙が滑り落ちる  
-2. 展開：「美咲へ」と書かれた母の筆跡に、手が震える  
-3. 転換：老婦人が「それは...春子さんが最後に書いた手紙です」と静かに告げる  
-4. 締め：二人は顔を見合わせ、20年の時が一瞬で繋がる  
-
-**このシーンで必ず描くこと**：  
-- [x] 手紙を見つけた瞬間の、時が止まったような感覚
-- [x] 母の筆跡を認識した時の、胸の奥が熱くなる感覚
-- [x] 老婦人の表情に浮かぶ、深い理解と共感
+**Act 3 (Resolution)**:
+1. The letter contains the feelings Misaki's mother wanted to convey to her.
+2. Through the old woman's words, Misaki rediscovers the meaning of continuing the bookstore.
+3. With new determination, a warm light illuminates the bookstore.
 
 ---
 
-## 品質チェック
+## Phase 2: Identify Important Scenes
 
-### ストーリー全体
-- [x] 主人公の価値観は一貫しているか？
-- [x] 物理的な矛盾はないか？
-- [x] 感情の流れは自然か？
-- [x] テーマは効果的に表現されているか？
-- [x] 読者を引き込む工夫はあるか？
+### Three Pillar Scenes of the Story
 
-### 要注意ポイント
-- [x] Lost in the Middle対策：重要情報は冒頭か結末に
-- [x] 物理描写は最小限に、心理描写を重視
-- [x] 各シーンに明確な役割があるか
+#### 1. Turning Point Scene "Reunion with the Book"
+**Location/Time**: Back of the dimly lit bookstore, 6:00 PM.
+**What happens**: Misaki finds the book the old woman was looking for in a corner of the shelf.
+**Protagonist's change**: Mere stock transforms into a special volume connected to her mother's memories.
+
+#### 2. Emotional Peak Scene "Discovery of the Letter"
+**Location/Time**: Bookstore counter, 6:30 PM.
+**What happens**: A letter dated 20 years ago falls from the pages of the book.
+**What you want the reader to feel**: The weight of feelings across time and the miracle of coincidence.
+
+#### 3. Theme Embodiment Scene "A New Light"
+**Location/Time**: Bookstore entrance, 7:00 PM.
+**What happens**: Misaki hangs up a sign that says "Open Tomorrow Too."
+**Relation to the theme**: The moment of accepting the past and stepping towards the future.
 
 ---
 
-## メモ・アイデア
+## Phase 3: Detailed Scene Design
 
-### 小道具の活用
-- 本：宮沢賢治「銀河鉄道の夜」初版本
-- 手紙：便箋3枚、万年筆で書かれている
-- 書店：「田中書店」創業50年の小さな店
+### Scene 1: Discovery of the Letter
 
-### 伏線
-- 冒頭で美咲が整理していた本が、まさに老婦人が探していた本
-- 母が生前よく話していた「特別なお客様」が老婦人だった
-- 手紙の日付が、母が亡くなる前日
+**External Situation**:
+- Location: In front of an old wooden counter.
+- Time: 6:30 PM, already dark outside.
+- Characters Present: Misaki, Old Woman (Kazuko Yamada).
 
-### セリフの例
-老婦人：「春子さんは言っていました。『本は人と人を繋ぐ架け橋』だと」
-美咲：「母は...最後まで、この店を愛していたんですね」
+**Internal Situation**:
+- Protagonist's emotion: A mixture of surprise and nostalgia.
+- Desired outcome: Wants to know her mother's feelings.
+- Feared outcome: Expectations being betrayed.
 
-### AIへの指示例
+**Scene Flow**:
+1. Introduction: The moment she tries to wrap the book in wrapping paper, the letter slips out.
+2. Development: Her hands tremble at her mother's handwriting addressed "To Misaki."
+3. Turning Point: The old woman quietly says, "That is... the last letter Haruko wrote."
+4. Conclusion: They look at each other, and 20 years connect in an instant.
+
+**Must-depict elements in this scene**:
+- [x] The feeling of time stopping the moment the letter is found.
+- [x] The warmth deep in her chest upon recognizing her mother's handwriting.
+- [x] The deep understanding and empathy visible on the old woman's face.
+
+---
+
+## Quality Check
+
+### Overall Story
+- [x] Is the protagonist's value consistent?
+- [x] Are there any physical contradictions?
+- [x] Is the flow of emotions natural?
+- [x] Is the theme effectively expressed?
+- [x] Are there devices to draw the reader in?
+
+### Key Points to Watch
+- [x] Lost in the Middle countermeasure: Important information at the beginning or end.
+- [x] Minimize physical descriptions, emphasize psychological descriptions.
+- [x] Does each scene have a clear role?
+
+---
+
+## Memos/Ideas
+
+### Utilizing Props
+- Book: First edition of Kenji Miyazawa's "Night on the Galactic Railroad"
+- Letter: 3 sheets of letter paper, written with a fountain pen
+- Bookstore: "Tanaka Shoten," a small shop established 50 years ago
+
+### Foreshadowing
+- The book Misaki was organizing at the beginning is the exact book the old woman was looking for.
+- The "special customer" her mother often talked about was the old woman.
+- The date on the letter is the day before her mother passed away.
+
+### Example Dialogue
+Old Woman: "Haruko used to say, 'Books are bridges that connect people.'"
+Misaki: "Mother... loved this store until the very end, didn't she?"
+
+### Example Instructions for AI
 ```
-美咲と老婦人が初めて出会うシーンを書いてください。
-- 美咲は疲れているが、丁寧に対応する
-- 老婦人は遠慮がちだが、確固とした目的がある
-- 書店の薄暗い雰囲気を大切に
-- 二人の間に流れる不思議な親近感を表現
+Write the scene where Misaki and the old woman first meet.
+- Misaki is tired but responds politely.
+- The old woman is hesitant but has a firm purpose.
+- Emphasize the dim atmosphere of the bookstore.
+- Express the mysterious sense of closeness flowing between them.
 ```
 
-### 執筆時の注意点
-1. 感傷的になりすぎない - 抑制の効いた感動を
-2. 説明的にならない - 行動と表情で感情を表現
-3. 母の人物像は手紙と老婦人の言葉から浮かび上がらせる
-4. 希望を感じる結末だが、安易な解決は避ける
+### Points to Note During Writing
+1. Don't be overly sentimental - aim for restrained emotion.
+2. Don't be explanatory - express emotions through actions and expressions.
+3. Let the mother's character emerge from the letter and the old woman's words.
+4. Aim for a hopeful ending, but avoid an overly simplistic resolution.
 ```

--- a/story-template/story-prompts.md
+++ b/story-template/story-prompts.md
@@ -1,234 +1,234 @@
-# 物語作成プロンプト集
+# Story Creation Prompt Collection
 
-## 基本の段階的構築法
+## Basic Step-by-Step Construction Method
 
-### Step 1: テーマと骨組み
+### Step 1: Theme and Framework
 ```
-以下の要素で物語の骨組みを作ってください：
+Create a story framework with the following elements:
 
-主人公：[キャラクター設定の要約]
-テーマ：[例：自己犠牲と自己実現の葛藤]
-ジャンル：[例：現代ドラマ]
+Protagonist: [Summary of character settings]
+Theme: [Example: Conflict between self-sacrifice and self-realization]
+Genre: [Example: Contemporary Drama]
 
-求めるもの：
-- 始まりと終わりの状況（各2行）
-- 3幕構成の要約（各幕3行程度）
-- 主人公の内的変化
-```
-
-### Step 2: 重要シーンの選定
-```
-[Step1で作った骨組み]
-
-この物語で最も重要な3つのシーンを選び、その役割を説明してください：
-
-1. 物語の転換点となるシーン
-2. 感情が最も高まるシーン
-3. テーマが最も強く表現されるシーン
-
-各シーンについて：
-- いつ、どこで
-- 何が起こるか
-- なぜ重要か
+Requirements:
+- Beginning and ending situations (2 lines each)
+- Summary of 3-act structure (approx. 3 lines per act)
+- Protagonist's internal change
 ```
 
-### Step 3: シーンの具体化
+### Step 2: Selection of Important Scenes
 ```
-[選んだシーンの詳細]
+[Framework created in Step 1]
 
-このシーンを以下の構成で書いてください：
+Select the three most important scenes in this story and explain their roles:
 
-1. 状況設定（場所、時間、雰囲気）- 2行
-2. 人物の行動と対話 - 10行程度
-3. 内面描写 - 5行程度  
-4. シーンの締め - 2行
+1. Scene that serves as the story's turning point
+2. Scene where emotions are at their peak
+3. Scene where the theme is most strongly expressed
 
-重要：
-- 物理的な動きは最小限に
-- 感情と内面の変化を中心に
-- 読者が状況を理解しやすいように
-```
-
-## 応用テクニック
-
-### 逆算プロット法
-```
-最終シーン：[主人公がどうなっているか]
-
-この結末に至るために：
-1. 主人公に必要な変化は？
-2. その変化を起こす出来事は？
-3. 変化前の主人公の状態は？
-
-これらを踏まえて、3幕構成を作成してください。
+For each scene:
+- When and where
+- What happens
+- Why it's important
 ```
 
-### 感情曲線設計
+### Step 3: Scene Concretization
 ```
-物語全体の感情の流れを設計してください：
+[Details of selected scene]
 
-開始時の感情レベル：[1-10]
-クライマックスの感情レベル：[1-10]
+Write this scene with the following structure:
 
-各章/シーンでの感情レベルと、
-その感情を生む出来事を設定。
+1. Situation setting (location, time, atmosphere) - 2 lines
+2. Character actions and dialogue - approx. 10 lines
+3. Internal monologue/description - approx. 5 lines
+4. Scene conclusion - 2 lines
 
-グラフのように山谷を作ることを意識。
-```
-
-### 読者体験の最適化
-```
-[作成したプロット]
-
-以下の観点で改善点を3つ提案してください：
-
-1. 冒頭で読者を引き込む工夫
-2. 中だるみを防ぐ仕掛け
-3. 満足感のある結末への調整
-
-各提案には具体的な修正案を含める。
+Important:
+- Minimize physical movement.
+- Focus on emotions and internal changes.
+- Make it easy for the reader to understand the situation.
 ```
 
-## ジャンル別プロンプト
+## Applied Techniques
 
-### ミステリー
+### Reverse Plotting Method
 ```
-[基本設定]
+Final Scene: [What happens to the protagonist]
 
-ミステリーの要素を追加してください：
+To reach this conclusion:
+1. What change does the protagonist need?
+2. What event triggers that change?
+3. What is the protagonist's state before the change?
 
-1. 謎の提示方法
-2. 手がかりの配置（フェアプレイ）
-3. 真相が明かされる瞬間の演出
-4. 動機の説得力
-
-読者が推理を楽しめる構成に。
+Based on these, create a 3-act structure.
 ```
 
-### 恋愛小説
+### Emotional Curve Design
 ```
-[基本設定]
+Design the overall emotional flow of the story:
 
-恋愛要素を深めてください：
+Emotional level at the start: [1-10]
+Emotional level at the climax: [1-10]
 
-1. 二人が惹かれ合う理由
-2. 障害となる要素
-3. 関係が深まる瞬間
-4. クライマックスでの選択
+Set the emotional level for each chapter/scene and
+the events that generate those emotions.
 
-感情の機微を丁寧に描写。
-```
-
-### ファンタジー
-```
-[基本設定]
-
-ファンタジー世界を構築してください：
-
-1. 世界観の独自ルール（魔法など）
-2. 主人公の特別な能力/使命
-3. 世界観がストーリーに与える影響
-4. ルールの制限と代償
-
-設定に溺れず、人間ドラマを中心に。
+Be conscious of creating peaks and valleys like a graph.
 ```
 
-## 文体・視点の設定
-
-### 一人称視点
+### Optimizing Reader Experience
 ```
-[物語の概要]
+[Created plot]
 
-主人公の一人称視点で冒頭を書いてください：
+Please suggest three improvements from the following perspectives:
 
-- 主人公の性格が表れる語り口
-- 読者との距離感
-- 知っていることと知らないことの区別
+1. Ways to draw the reader in at the beginning
+2. Devices to prevent a sagging middle
+3. Adjustments for a satisfying conclusion
 
-200字程度で。
+Include specific revision suggestions for each proposal.
 ```
 
-### 三人称限定視点
+## Genre-Specific Prompts
+
+### Mystery
 ```
-[物語の概要]
+[Basic Settings]
 
-特定キャラクターの視点から三人称で書いてください：
+Please add mystery elements:
 
-- 視点人物の内面は描写可
-- 他者の内面は行動から推測
-- 視点の一貫性を保つ
+1. How the mystery is presented
+2. Placement of clues (fair play)
+3. Staging of the moment the truth is revealed
+4. Persuasiveness of the motive
 
-視点の利点を活かした描写を。
-```
-
-### 神視点
-```
-[物語の概要]
-
-全知の語り手として場面を描写してください：
-
-- 複数の人物の内面を描ける
-- 時間と空間を自由に移動
-- 情報の出し方に注意
-
-俯瞰的な視点の利点を活用。
+Structure it so readers can enjoy deducing.
 ```
 
-## シーン転換テクニック
-
-### 時間経過の表現
+### Romance Novel
 ```
-[前のシーン]→[次のシーン]
+[Basic Settings]
 
-この2つのシーンを自然につなぐ転換を書いてください：
+Please deepen the romance elements:
 
-- 時間経過の示し方
-- 場所の変化
-- 人物の心理的変化
+1. Reasons the two are attracted to each other
+2. Obstacles
+3. Moments when the relationship deepens
+4. Choices at the climax
 
-唐突にならないよう配慮。
-```
-
-### 緊張感の維持
-```
-[盛り上がったシーン]の後
-
-緊張感を維持したまま次のシーンに移る方法を提案してください：
-
-- クリフハンガー
-- 謎の提示
-- 新たな問題の予感
+Depict emotional subtleties carefully.
 ```
 
-## AIとの効果的な対話法
+### Fantasy
+```
+[Basic Settings]
 
-### 詳細な指示
-```
-悪い例：「感動的なシーンを書いて」
-良い例：「主人公が亡き母の手紙を見つけるシーン。
-        場所は実家の屋根裏。埃っぽい空気と
-        差し込む夕日。手紙には...」
-```
+Please construct a fantasy world:
 
-### 段階的な構築
-```
-1回目：プロット作成
-2回目：重要シーンの特定
-3回目：各シーンの詳細化
-4回目：つなぎの部分を補完
+1. Unique world rules (magic, etc.)
+2. Protagonist's special ability/mission
+3. Impact of the world view on the story
+4. Limitations and costs of rules
+
+Focus on human drama without getting bogged down in settings.
 ```
 
-### フィードバックループ
+## Setting Style and Viewpoint
+
+### First-Person Viewpoint
 ```
-生成されたテキストに対して：
+[Story Outline]
 
-「良かった点：[具体的に]
-改善してほしい点：[具体的に]
-追加してほしい要素：[具体的に]」
+Write the beginning from the protagonist's first-person viewpoint:
 
-これを繰り返して洗練させる。
+- Narrative style that reveals the protagonist's personality
+- Distance from the reader
+- Distinction between what is known and unknown
+
+Around 200 characters.
+```
+
+### Third-Person Limited Viewpoint
+```
+[Story Outline]
+
+Write from a specific character's third-person viewpoint:
+
+- Internal thoughts of the viewpoint character can be described.
+- Internal thoughts of others are inferred from actions.
+- Maintain consistency of viewpoint.
+
+Utilize the advantages of this viewpoint in the description.
+```
+
+### Omniscient Viewpoint
+```
+[Story Outline]
+
+Describe the scene as an omniscient narrator:
+
+- Can depict the internal thoughts of multiple characters.
+- Can move freely through time and space.
+- Be careful about how information is revealed.
+
+Utilize the advantages of an omniscient viewpoint.
+```
+
+## Scene Transition Techniques
+
+### Expressing Passage of Time
+```
+[Previous Scene] → [Next Scene]
+
+Write a transition that naturally connects these two scenes:
+
+- How to show time passage
+- Change of location
+- Character's psychological change
+
+Take care not to be abrupt.
+```
+
+### Maintaining Suspense
+```
+After [a climactic scene]
+
+Suggest ways to move to the next scene while maintaining suspense:
+
+- Cliffhanger
+- Presentation of a mystery
+- Foreshadowing of a new problem
+```
+
+## Effective Dialogue with AI
+
+### Detailed Instructions
+```
+Bad Example: "Write a moving scene."
+Good Example: "Scene where the protagonist finds their deceased mother's letter.
+        Location is the attic of their family home. Dusty air and
+        setting sunbeams. The letter contains..."
+```
+
+### Incremental Construction
+```
+1st time: Create plot
+2nd time: Identify important scenes
+3rd time: Detail each scene
+4th time: Supplement transitions
+```
+
+### Feedback Loop
+```
+For generated text:
+
+"Good points: [Specifically]
+Points to improve: [Specifically]
+Elements to add: [Specifically]"
+
+Repeat this to refine.
 ```
 
 ---
 
-💡 **プロンプトは道具です。** あなたの創造性を制限するものではなく、引き出すためのものです。自由にカスタマイズして、あなただけの物語を紡いでください。
+💡 **Prompts are tools.** They are not meant to limit your creativity, but to draw it out. Feel free to customize them and weave your own unique story.

--- a/story-template/techniques.md
+++ b/story-template/techniques.md
@@ -1,225 +1,225 @@
-# 物語作成テクニック集
+# Story Creation Technique Collection
 
-## 🎨 AI時代の物語創作術
+## 🎨 Story Creation Techniques in the AI Era
 
-### なぜAIは物語創作に向いているのか
-1. **無限のアイデア生成**: 制約なく可能性を探れる
-2. **客観的な視点**: 作者の思い込みから解放される
-3. **高速な試行錯誤**: 複数のバージョンを瞬時に比較
-4. **一貫性の維持**: 設定を忘れない完璧な記憶力
+### Why is AI Suited for Story Creation?
+1. **Infinite Idea Generation**: Can explore possibilities without constraints.
+2. **Objective Perspective**: Frees from the author's biases.
+3. **Rapid Trial and Error**: Instantly compare multiple versions.
+4. **Consistency Maintenance**: Perfect memory that doesn't forget settings.
 
-### AIの限界を理解した創作
-1. **Lost in the Middle現象**: 長文の中央部分を忘れやすい
-2. **物理的な矛盾**: 空間把握が苦手
-3. **微妙な感情表現**: 人間の複雑な心理の理解
-4. **独創性の限界**: 既存パターンの組み合わせ
+### Creating with an Understanding of AI's Limitations
+1. **Lost in the Middle Phenomenon**: Tends to forget the middle part of long texts.
+2. **Physical Contradictions**: Struggles with spatial awareness.
+3. **Subtle Emotional Expression**: Understanding complex human psychology.
+4. **Limits of Originality**: Combination of existing patterns.
 
-## 📐 構造的アプローチ
+## 📐 Structural Approaches
 
-### 1. スノーフレーク法 × AI
+### 1. Snowflake Method x AI
 ```
-中心：一文で物語を表現
-　↓
-展開：一文を段落に
-　↓
-詳細：段落を章に
-　↓
-具体：章をシーンに
-```
-
-**AIプロンプト例**：
-```
-「孤独な少女が友情を通じて自分の価値を見出す物語」を
-スノーフレーク法で展開してください。
-まず3つの段落で展開し、
-次に各段落を3つの章に分けてください。
+Core: Express the story in one sentence
+  ↓
+Expansion: Expand the sentence into a paragraph
+  ↓
+Detail: Expand the paragraph into chapters
+  ↓
+Specifics: Expand chapters into scenes
 ```
 
-### 2. シーンカード法
-各シーンを独立したカードとして作成し、後で組み合わせる。
-
-**カード内容**：
-- シーンの目的
-- 登場人物
-- 感情の変化
-- 次への伏線
-
-**利点**：
-- 順序の入れ替えが容易
-- 不要なシーンの削除が簡単
-- AIが各シーンに集中できる
-
-### 3. 感情グラフ法
+**AI Prompt Example**:
 ```
-感情レベル
+Expand the story "A lonely girl discovers her own worth through friendship"
+using the Snowflake Method.
+First, expand into three paragraphs,
+then divide each paragraph into three chapters.
+```
+
+### 2. Scene Card Method
+Create each scene as an independent card and combine them later.
+
+**Card Content**:
+- Purpose of the scene
+- Characters present
+- Emotional changes
+- Foreshadowing for the next part
+
+**Advantages**:
+- Easy to reorder
+- Simple to delete unnecessary scenes
+- Allows AI to focus on each scene
+
+### 3. Emotion Graph Method
+```
+Emotion Level
 10 |    ★
  8 |   / \
  6 |  /   \  ★
  4 | /     \/
  2 |★      
  0 |____________
-   開始  中盤  終盤
+   Start Middle End
 ```
 
-各ポイントでの出来事を設定し、感情の起伏を設計。
+Set events at each point and design emotional fluctuations.
 
-## 🔧 実践的テクニック
+## 🔧 Practical Techniques
 
-### テクニック1: プロンプト・チェイニング
-前の出力を次の入力に使う連鎖的な創作。
-
-```
-1. キャラクター作成
-　　↓（結果を利用）
-2. そのキャラクターでプロット作成
-　　↓（結果を利用）
-3. プロットから重要シーン抽出
-　　↓（結果を利用）
-4. 各シーンを詳細化
-```
-
-### テクニック2: パラレル生成
-同じプロンプトで複数バージョンを生成し、良い部分を組み合わせる。
+### Technique 1: Prompt Chaining
+Sequential creation using the previous output as the next input.
 
 ```
-バージョンA：感情重視
-バージョンB：アクション重視
-バージョンC：対話重視
-→ 各バージョンの良い部分を統合
+1. Character creation
+    ↓ (Utilize result)
+2. Plot creation with that character
+    ↓ (Utilize result)
+3. Extraction of important scenes from the plot
+    ↓ (Utilize result)
+4. Detailing each scene
 ```
 
-### テクニック3: 制約クリエイティブ
-あえて厳しい制約を設定して創造性を引き出す。
+### Technique 2: Parallel Generation
+Generate multiple versions with the same prompt and combine the good parts.
 
-**制約の例**：
-- 100文字で1章を表現
-- 5つの単語だけで場面を描写
-- 主人公が一言も話さない
-
-## 🎭 キャラクター駆動の物語
-
-### 対立から生まれるドラマ
 ```
-キャラクターA：価値観X
-　　　VS
-キャラクターB：価値観Y
-
-この対立が物語を推進
+Version A: Emotion-focused
+Version B: Action-focused
+Version C: Dialogue-focused
+→ Integrate the good parts of each version
 ```
 
-**プロンプト例**：
+### Technique 3: Constraint Creativity
+Draw out creativity by intentionally setting strict constraints.
+
+**Examples of Constraints**:
+- Express one chapter in 100 characters
+- Describe a scene with only 5 words
+- The protagonist does not speak a single word
+
+## 🎭 Character-Driven Story
+
+### Drama Born from Conflict
 ```
-「完璧主義の兄」と「自由奔放な妹」の
-価値観の対立から生まれる
-家族ドラマを構築してください。
-```
+Character A: Value X
+      VS
+Character B: Value Y
 
-### 内的葛藤の外在化
-キャラクターの内面の葛藤を、外的な出来事として表現。
-
-**例**：
-- 内的葛藤：自信の欠如
-- 外在化：重要なプレゼンでの失敗
-- 展開：失敗を乗り越える過程で成長
-
-## 📝 文体とトーン
-
-### 文体の一貫性維持
-**初回プロンプトに含める要素**：
-1. 希望する文体の例文
-2. 避けたい表現のリスト
-3. 目指す雰囲気のキーワード
-
-### ジャンル別文体
-**ミステリー**：
-- 客観的で冷静な描写
-- 細部への注目
-- 論理的な文章構成
-
-**恋愛小説**：
-- 感情豊かな描写
-- 内面の細やかな変化
-- 比喩を多用した表現
-
-**ファンタジー**：
-- 壮大で詩的な描写
-- 造語の効果的な使用
-- 世界観を感じさせる文体
-
-## 🚀 生産性向上テクニック
-
-### バッチ処理
-類似タスクをまとめて処理：
-1. 全キャラクターの設定を一度に
-2. 全章のあらすじを一度に
-3. 全シーンの冒頭を一度に
-
-### テンプレート活用
-```
-シーンテンプレート：
-【場所】：
-【時間】：
-【登場人物】：
-【目的】：このシーンで達成すること
-【開始】：最初の一文
-【展開】：3-5文で展開
-【結末】：締めの一文
-【次への橋渡し】：
+This conflict drives the story
 ```
 
-### リビジョン戦略
-1. **第一稿**：構造とプロットに集中
-2. **第二稿**：キャラクターの一貫性
-3. **第三稿**：文体と表現の洗練
-4. **最終稿**：細部の調整
+**Prompt Example**:
+```
+Construct a family drama
+born from the value conflict between
+a "perfectionist older brother" and a "free-spirited younger sister."
+```
 
-## 💡 トラブルシューティング
+### Externalizing Internal Conflict
+Express a character's internal conflict as an external event.
 
-### よくある問題と解決法
+**Example**:
+- Internal conflict: Lack of confidence
+- Externalization: Failure in an important presentation
+- Development: Growth in the process of overcoming failure
 
-**問題1：中だるみ**
-- 解決：サブプロットを追加
-- 解決：時間軸をシャッフル
-- 解決：新キャラクター投入
+## 📝 Style and Tone
 
-**問題2：キャラクターが立たない**
-- 解決：特徴的な口癖を設定
-- 解決：他者との対比を強調
-- 解決：意外な一面を追加
+### Maintaining Stylistic Consistency
+**Elements to include in the initial prompt**:
+1. Example sentences of the desired style.
+2. List of expressions to avoid.
+3. Keywords for the target atmosphere.
 
-**問題3：終わり方が決まらない**
-- 解決：複数エンディングを生成
-- 解決：テーマから逆算
-- 解決：読者の期待を裏切る
+### Style by Genre
+**Mystery**:
+- Objective and calm descriptions.
+- Attention to detail.
+- Logical sentence structure.
 
-## 🎯 品質向上のチェックリスト
+**Romance Novel**:
+- Emotionally rich descriptions.
+- Subtle changes in inner thoughts.
+- Frequent use of metaphors.
 
-### 初稿完成後の確認事項
-- [ ] 各章に明確な役割があるか
-- [ ] 伏線は回収されているか
-- [ ] キャラクターアークは完成しているか
-- [ ] テーマは一貫しているか
-- [ ] 読者の感情曲線は設計通りか
+**Fantasy**:
+- Grand and poetic descriptions.
+- Effective use of neologisms.
+- Style that evokes the world view.
 
-### ブラッシュアップのポイント
-1. **冒頭の3行**で読者を掴めているか
-2. **各章の終わり**に次を読みたくなる仕掛けがあるか
-3. **クライマックス**は期待を超えているか
-4. **結末**は満足感を与えているか
+## 🚀 Productivity Improvement Techniques
 
-## 🔮 未来の創作スタイル
+### Batch Processing
+Process similar tasks together:
+1. All character settings at once.
+2. Synopses of all chapters at once.
+3. Beginnings of all scenes at once.
 
-### AIとの共創の形
-1. **アイデア生成**：AIが可能性を提示
-2. **構造設計**：人間が全体を俯瞰
-3. **詳細執筆**：AIが文章を生成
-4. **編集・洗練**：人間が最終調整
+### Utilizing Templates
+```
+Scene Template:
+【Location】:
+【Time】:
+【Characters Present】:
+【Purpose】: What to achieve in this scene
+【Beginning】: First sentence
+【Development】: Expand in 3-5 sentences
+【Conclusion】: Closing sentence
+【Bridge to Next】:
+```
 
-### 新しい物語形式
-- **インタラクティブ小説**：読者の選択で変化
-- **マルチエンディング**：AIが複数の結末を用意
-- **リアルタイム生成**：読者に合わせてカスタマイズ
+### Revision Strategy
+1. **First Draft**: Focus on structure and plot.
+2. **Second Draft**: Character consistency.
+3. **Third Draft**: Refinement of style and expression.
+4. **Final Draft**: Fine-tuning details.
+
+## 💡 Troubleshooting
+
+### Common Problems and Solutions
+
+**Problem 1: Sagging Middle**
+- Solution: Add a subplot.
+- Solution: Shuffle the timeline.
+- Solution: Introduce a new character.
+
+**Problem 2: Character Lacks Presence**
+- Solution: Set a characteristic catchphrase.
+- Solution: Emphasize contrast with others.
+- Solution: Add an unexpected aspect.
+
+**Problem 3: Can't Decide on an Ending**
+- Solution: Generate multiple endings.
+- Solution: Work backward from the theme.
+- Solution: Subvert reader expectations.
+
+## 🎯 Quality Improvement Checklist
+
+### Post-First Draft Checklist
+- [ ] Does each chapter have a clear role?
+- [ ] Is foreshadowing resolved?
+- [ ] Is the character arc complete?
+- [ ] Is the theme consistent?
+- [ ] Is the reader's emotional curve as designed?
+
+### Points for Polishing
+1. Do the **first 3 lines** grab the reader?
+2. Is there a hook at the **end of each chapter** to make them want to read on?
+3. Does the **climax** exceed expectations?
+4. Does the **ending** provide satisfaction?
+
+## 🔮 Future Creation Styles
+
+### Forms of Co-creation with AI
+1. **Idea Generation**: AI presents possibilities.
+2. **Structural Design**: Humans oversee the whole.
+3. **Detailed Writing**: AI generates text.
+4. **Editing & Refinement**: Humans make final adjustments.
+
+### New Story Formats
+- **Interactive Novels**: Change based on reader choices.
+- **Multiple Endings**: AI prepares several conclusions.
+- **Real-time Generation**: Customized to the reader.
 
 ---
 
-🌟 **創作の本質は変わらない**：テクノロジーは道具。大切なのは、読者の心に響く物語を紡ぐこと。AIはその可能性を広げる、強力なパートナーです。
+🌟 **The essence of creation remains unchanged**: Technology is a tool. What's important is to weave stories that resonate with readers' hearts. AI is a powerful partner that expands those possibilities.


### PR DESCRIPTION
This commit includes the translation of all user-facing Markdown files from Japanese to English.

- Translated README, QUICK_START, WORKSPACE_GUIDE.
- Translated all command documentation in .claude/commands/.
- Translated all character templates, examples, and tips in character-template/.
- Translated all story templates, examples, and tips in story-template/.
- Translated all quality check documents in quality-check/.
- Translated all resource documents (principles, constraints, workflow) in resources/.
- Updated CLAUDE.md to reflect the project's new language and translated terms.
- Ensured consistent terminology for key concepts across all translated files.